### PR TITLE
Basic RHCOS publishing structure

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+unset BUILD_ONLY
+
+while getopts "b" arg; do
+	case $arg in
+	b)
+		export BUILD_ONLY=true
+		;;
+	esac
+done
+
+export TAG_SUFFIX=$(date +"%y%m%d%H%M")
+
+(
+	source rhcos/interface.sh
+	SHASUM=$(containerdisks::needs_update 4.9)
+	if [ -n "${SHASUM}" ]; then
+		docker build -t quay.io/containerdisks/rhcos:4.9 -t quay.io/containerdisks/rhcos:4.9-${TAG_SUFFIX} --label "shasum=${SHASUM}" -f rhcos/4.9/Dockerfile .
+		if [ -z "${BUILD_ONLY}" ]; then
+			docker push quay.io/containerdisks/rhcos:4.9-${TAG_SUFFIX}
+			docker push quay.io/containerdisks/rhcos:4.9
+		fi
+	fi
+)

--- a/rhcos/4.9/Dockerfile
+++ b/rhcos/4.9/Dockerfile
@@ -1,0 +1,7 @@
+FROM alpine as builder
+RUN wget https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/latest/rhcos-openstack.x86_64.qcow2.gz
+RUN wget -O - https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/latest/sha256sum.txt | grep rhcos-openstack.x86_64.qcow2.gz | sha256sum -c
+RUN gzip -d rhcos-openstack.x86_64.qcow2.gz
+
+FROM scratch                                                                                                    
+COPY --chown=107:107 --from=builder /rhcos-openstack.x86_64.qcow2 /disk/rhcos-openstack.x86_64.qcow2

--- a/rhcos/interface.sh
+++ b/rhcos/interface.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+function containerdisks::needs_update() {
+  local tag=$1
+  local latest_shasum="$(curl https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/${tag}/latest/sha256sum.txt | grep rhcos-openstack.x86_64.qcow2.gz | awk '{ print $1}')"
+  echo >&2 "Latest shasum for rhcos:${tag}: ${latest_shasum}"
+  local release_shasum="$(skopeo inspect --no-tags docker://quay.io/containerdisks/rhcos:${tag} --format '{{ .Labels.shasum }}')"
+  echo >&2 "Published shasum for rhcos:${tag}: ${release_shasum}"
+  if [[ "${latest_shasum}" == "${release_shasum}" ]]; then
+    echo >&2 "No update for rhcos:${tag} required"
+  else
+    echo >&2 "Update for rhcos:${tag} required"
+    echo "${latest_shasum}"
+  fi
+}


### PR DESCRIPTION
A basic easy extensible structure to publish repos.
More generalization is possible, but the basics are there.

The Dockerfile for rhcos always downloads the latest rhco 4.9 image and
verifies that the published shasum matches the download.

The build script on top, makes use of an interface function
`containerdisks::needs_update` which returns the shasum of the new
to-download image, or returns nothing if no update is necessary.

This function can work since every containerdisk gets labeled with the
shasum of the containerdisk file itself. Skopeo queries the remote image
to get the info.