### PR TITLE
Add a Fedora 35 containerdisk

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,23 +5,30 @@ set -e -o pipefail
 unset BUILD_ONLY
 
 while getopts "b" arg; do
-	case $arg in
-	b)
-		export BUILD_ONLY=true
-		;;
-	esac
+  case $arg in
+  b)
+    export BUILD_ONLY=true
+    ;;
+  esac
 done
 
 export TAG_SUFFIX=$(date +"%y%m%d%H%M")
 
-(
-	source rhcos/interface.sh
-	SHASUM=$(containerdisks::needs_update 4.9)
-	if [ -n "${SHASUM}" ]; then
-		docker build -t quay.io/containerdisks/rhcos:4.9 -t quay.io/containerdisks/rhcos:4.9-${TAG_SUFFIX} --label "shasum=${SHASUM}" -f rhcos/4.9/Dockerfile .
-		if [ -z "${BUILD_ONLY}" ]; then
-			docker push quay.io/containerdisks/rhcos:4.9-${TAG_SUFFIX}
-			docker push quay.io/containerdisks/rhcos:4.9
-		fi
-	fi
-)
+function build() {
+  export distro=$1
+  export tag=$2
+  (
+    source ${distro}/interface.sh
+    SHASUM=$(containerdisks::needs_update ${tag})
+    if [ -n "${SHASUM}" ]; then
+      docker build -t quay.io/containerdisks/${distro}:${tag} -t quay.io/containerdisks/${distro}:${tag}-${TAG_SUFFIX} --label "shasum=${SHASUM}" -f ${distro}/${tag}/Dockerfile .
+      if [ -z "${BUILD_ONLY}" ]; then
+        docker push quay.io/containerdisks/${distro}:${tag}-${TAG_SUFFIX}
+        docker push quay.io/containerdisks/${distro}:${tag}
+      fi
+    fi
+  )
+}
+
+build rhcos 4.9
+build fedora 35

--- a/fedora/35/Dockerfile
+++ b/fedora/35/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine as builder
+ENV VERSION=35
+RUN apk add wget jq
+RUN wget https://getfedora.org/releases.json
+RUN wget -O disk.qcow2 $(cat releases.json | jq -r --arg VERSION $VERSION '.[] | select(.link|test(".*qcow2")) | select(.variant=="Cloud" and .arch=="x86_64" and .version==$VERSION).link')
+RUN echo "$(cat releases.json | jq -r --arg VERSION $VERSION '.[] | select(.link|test(".*qcow2")) | select(.variant=="Cloud" and .arch=="x86_64" and .version==$VERSION).sha256')  disk.qcow2" | sha256sum -c
+
+FROM scratch                                                                                                    
+COPY --chown=107:107 --from=builder /disk.qcow2 /disk/disk.qcow2

--- a/fedora/interface.sh
+++ b/fedora/interface.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+function containerdisks::needs_update() {
+  local tag=$1
+  local latest_shasum="$(curl https://getfedora.org/releases.json | jq -r --arg VERSION $tag '.[] | select(.link|test(".*qcow2")) | select(.variant=="Cloud" and .arch=="x86_64" and .version==$VERSION).sha256')"
+  echo >&2 "Latest shasum for fedora:${tag}: ${latest_shasum}"
+  local release_shasum="$(skopeo inspect --no-tags docker://quay.io/containerdisks/fedora:${tag} --format '{{ .Labels.shasum }}')"
+  echo >&2 "Published shasum for fedora:${tag}: ${release_shasum}"
+  if [[ "${latest_shasum}" == "${release_shasum}" ]]; then
+    echo >&2 "No update for fedora:${tag} required"
+  else
+    echo >&2 "Update for fedora:${tag} required"
+    echo "${latest_shasum}"
+  fi
+}


### PR DESCRIPTION
Add a Fedora 35 containerdisk to the build process. Like the rhcos image it will detect shasum differences and rebuild in the periodic job if necessary.

```release-note
Add a Fedora 35 containerdisk
```