### PR TITLE
Append a slash to tar directory entries

### DIFF
--- a/pkg/build/tar.go
+++ b/pkg/build/tar.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 func StreamLayer(imagePath string) (tarReader io.ReadCloser, errChan chan error) {
@@ -39,8 +40,13 @@ func addFileToTarWriter(filePath string, tarWriter *tar.Writer) error {
 
 	header := &tar.Header{
 		Typeflag: tar.TypeDir,
-		Name:     "disk",
+		Name:     "disk/",
 		Mode:     0555,
+		Uid:      107,
+		Gid:      107,
+		Uname:    "qemu",
+		Gname:    "qemu",
+		ModTime:  time.Now(),
 	}
 
 	err = tarWriter.WriteHeader(header)

--- a/pkg/build/tar_test.go
+++ b/pkg/build/tar_test.go
@@ -1,0 +1,62 @@
+package build
+
+import (
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestStreamLayer(t *testing.T) {
+	type args struct {
+		imageContent string
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "should create the tar file in an expected format",
+			args: args{imageContent: "hello"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewGomegaWithT(t)
+			imageName := filepath.Join(t.TempDir(), "image")
+
+			err := os.WriteFile(imageName, []byte(tt.args.imageContent), 0777)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			imageStat, err := os.Stat(imageName)
+			g.Expect(err).ToNot(HaveOccurred())
+
+			reader, errChan := StreamLayer(imageName)
+
+			tarReader := tar.NewReader(reader)
+
+			dir, err := tarReader.Next()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(dir.Name).To(Equal("disk/"))
+			g.Expect(int32(dir.Typeflag)).To(Equal(tar.TypeDir))
+			g.Expect(dir.Uid).To(Equal(107))
+			g.Expect(dir.Gid).To(Equal(107))
+
+			image, err := tarReader.Next()
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(image.Name).To(Equal("disk/disk.img"))
+			g.Expect(int32(image.Typeflag)).To(Equal(tar.TypeReg))
+			g.Expect(image.Size).To(Equal(imageStat.Size()))
+			g.Expect(image.Uid).To(Equal(107))
+			g.Expect(image.Gid).To(Equal(107))
+			data, err := ioutil.ReadAll(tarReader)
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(string(data)).To(Equal(tt.args.imageContent))
+
+			g.Expect(errChan).ToNot(Receive())
+		})
+	}
+}


### PR DESCRIPTION
CDI detects the disk directory entry as a regular file due to checking
if the tar header points to a directory by checking if it is appended
with a slash instead of checking the tar type.

To make the images works with all all CDI versions as well as meeting
this expectation in general (most apps append a slash), adding a slash
to the directories here too.

An improvment to CDI is here: https://github.com/kubevirt/containerized-data-importer/pull/2050

```release-note
Append a slash to the disk directory tar header to not confuse CDI
```