### PR TITLE
Deal with a quay.io strangeness when tags get deleted

### DIFF
--- a/cmd/medius/publish.go
+++ b/cmd/medius/publish.go
@@ -100,6 +100,8 @@ func buildAndPublish(artifact api.Artifact, options *Options, timestamp time.Tim
 			log.Info("Repository does not yet exist, it will be created")
 		} else if repository.IsManifestUnknownError(err) {
 			log.Info("Tag does not yet exist, it will be created")
+		} else if repository.IsTagUnknownError(err) {
+			log.Info("Tag is gone but seems to have existed already, it will be created")
 		} else {
 			return fmt.Errorf("error introspecting image %q: %v", imageName, err)
 		}

--- a/pkg/repository/repository.go
+++ b/pkg/repository/repository.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/containers/image/v5/image"
@@ -107,6 +108,17 @@ func IsRepositoryUnknownError(err error) bool {
 	default:
 		return false
 	}
+}
+
+func IsTagUnknownError(err error) bool {
+	e := getErrorCode(err)
+	if e.ErrorCode().Error() == "unknown" {
+		// errors like this have no explicit error handling: "unknown: Tag 5.2 was deleted or has expired. To pull, revive via time machine"
+		if strings.Contains(err.Error(), "was deleted or has expired. To pull, revive via time machine") {
+			return true
+		}
+	}
+	return false
 }
 
 func getErrorCode(err error) errcode.ErrorCoder {


### PR DESCRIPTION
Quay seems to remember when tags have existed and returns a special
error which is not handled by generic libraries in this case. To deal
with it, literally compare strings to detect this kind of error.


```release-note
NONE
```