### PR TITLE
Add --[source|target]-registry flags to images push cmd

### DIFF
--- a/cmd/medius/common/options.go
+++ b/cmd/medius/common/options.go
@@ -4,7 +4,6 @@ type Options struct {
 	AllowInsecureRegistry bool
 	DryRun                bool
 	Focus                 string
-	Registry              string
 	ImagesOptions         ImagesOptions
 	PublishDocsOptions    PublishDocsOptions
 	PublishImagesOptions  PublishImageOptions
@@ -23,14 +22,18 @@ type PromoteImageOptions struct {
 }
 
 type PublishDocsOptions struct {
+	Registry  string
 	TokenFile string
 }
 
 type PublishImageOptions struct {
-	ForceBuild bool
+	ForceBuild     bool
+	SourceRegistry string
+	TargetRegistry string
 }
 
 type VerifyImageOptions struct {
+	Registry  string
 	Namespace string
 	Timeout   int
 }

--- a/cmd/medius/images/verify.go
+++ b/cmd/medius/images/verify.go
@@ -88,9 +88,15 @@ func NewVerifyImagesCommand(options *common.Options) *cobra.Command {
 			}
 		},
 	}
+	verifyCmd.Flags().StringVar(&options.VerifyImagesOptions.Registry, "registry", options.VerifyImagesOptions.Registry, "Registry that contains containerdisks to verify")
 	verifyCmd.Flags().StringVar(&options.VerifyImagesOptions.Namespace, "namespace", options.VerifyImagesOptions.Namespace, "Namespace to run verify in")
 	verifyCmd.Flags().IntVar(&options.VerifyImagesOptions.Timeout, "timeout", options.VerifyImagesOptions.Timeout, "Maximum seconds to wait for VM to be running")
 	verifyCmd.Flags().AddGoFlagSet(kvirtcli.FlagSet())
+
+	err := verifyCmd.MarkFlagRequired("registry")
+	if err != nil {
+		logrus.Fatal(err)
+	}
 
 	return verifyCmd
 }
@@ -104,7 +110,7 @@ func verifyArtifact(ctx context.Context, artifact api.Artifact, result api.Artif
 		return err
 	}
 
-	imgRef := path.Join(options.Registry, result.Tags[0])
+	imgRef := path.Join(options.VerifyImagesOptions.Registry, result.Tags[0])
 	vm, privateKey, err := createVM(artifact, imgRef)
 	if err != nil {
 		log.WithError(err).Error("Failed to create VM object")

--- a/cmd/medius/main.go
+++ b/cmd/medius/main.go
@@ -14,8 +14,7 @@ import (
 
 func main() {
 	options := &common.Options{
-		DryRun:   true,
-		Registry: "quay.io/containerdisks",
+		DryRun: true,
 		ImagesOptions: common.ImagesOptions{
 			ResultsFile: "results.json",
 			Workers:     1,
@@ -48,7 +47,6 @@ func main() {
 	imagesCmd.AddCommand(images.NewVerifyImagesCommand(options))
 	docsCmd.AddCommand(docs.NewPublishDocsCommand(options))
 
-	rootCmd.PersistentFlags().StringVar(&options.Registry, "registry", options.Registry, "target registry for the containerdisks")
 	rootCmd.PersistentFlags().BoolVar(&options.AllowInsecureRegistry, "insecure-skip-tls", options.AllowInsecureRegistry, "allow connecting to insecure registries")
 	rootCmd.PersistentFlags().BoolVar(&options.DryRun, "dry-run", options.DryRun, "don't publish anything")
 	rootCmd.PersistentFlags().StringVar(&options.Focus, "focus", options.Focus, "Focus on a specific containerdisk")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This allows to specify a source registry to check if updates are needed
and a target registry to push freshly built containerdisks to.
In general this makes specifying registries less ambiguous.

**Special notes for your reviewer**:

Merge after #21

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow to specify a source registry to check if new containerdisks need to be built.
Allow to specify a target registry to push freshly built containerdisks to.
```
