### PR TITLE
Add images promote cmd

### DIFF
--- a/cmd/medius/common/options.go
+++ b/cmd/medius/common/options.go
@@ -8,12 +8,18 @@ type Options struct {
 	ImagesOptions         ImagesOptions
 	PublishDocsOptions    PublishDocsOptions
 	PublishImagesOptions  PublishImageOptions
+	PromoteImageOptions   PromoteImageOptions
 	VerifyImagesOptions   VerifyImageOptions
 }
 
 type ImagesOptions struct {
 	ResultsFile string
 	Workers     int
+}
+
+type PromoteImageOptions struct {
+	SourceRegistry string
+	TargetRegistry string
 }
 
 type PublishDocsOptions struct {

--- a/cmd/medius/images/promote.go
+++ b/cmd/medius/images/promote.go
@@ -1,0 +1,110 @@
+package images
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	"kubevirt.io/containerdisks/cmd/medius/common"
+	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/repository"
+)
+
+func NewPromoteImagesCommand(options *common.Options) *cobra.Command {
+	options.PromoteImageOptions = common.PromoteImageOptions{
+		TargetRegistry: "quay.io/containerdisks",
+	}
+
+	promoteCmd := &cobra.Command{
+		Use:   "promote",
+		Short: "Promote verified containerdisks from one registry to another registry",
+		Run: func(cmd *cobra.Command, args []string) {
+			results, err := readResultsFile(options.ImagesOptions.ResultsFile)
+			if err != nil {
+				logrus.Fatal(err)
+			}
+
+			resultsChan, err := spawnWorkers(cmd.Context(), options, func(a api.Artifact) (*api.ArtifactResult, error) {
+				r, ok := results[a.Metadata().Describe()]
+				if !ok {
+					return nil, nil
+				}
+				if r.Err != "" {
+					return nil, fmt.Errorf("Artifact %s failed in stage %s: %s", a.Metadata().Describe(), r.Stage, r.Err)
+				}
+				if r.Stage != StageVerify {
+					return nil, nil
+				}
+
+				errString := ""
+				err := promoteArtifact(cmd.Context(), a, r.Tags, options)
+				if err != nil {
+					errString = err.Error()
+				}
+
+				return &api.ArtifactResult{
+					Tags:  r.Tags,
+					Stage: StagePromote,
+					Err:   errString,
+				}, err
+			})
+
+			for result := range resultsChan {
+				results[result.Key] = result.Value
+			}
+
+			if !options.DryRun {
+				if err := writeResultsFile(options.ImagesOptions.ResultsFile, results); err != nil {
+					logrus.Fatal(err)
+				}
+			}
+
+			if err != nil {
+				logrus.Fatal(err)
+			}
+		},
+	}
+	promoteCmd.Flags().StringVar(&options.PromoteImageOptions.SourceRegistry, "source-registry", options.PromoteImageOptions.SourceRegistry, "Registry to pull images from")
+	promoteCmd.Flags().StringVar(&options.PromoteImageOptions.TargetRegistry, "target-registry", options.PromoteImageOptions.TargetRegistry, "Registry to promote images to")
+
+	err := promoteCmd.MarkFlagRequired("source-registry")
+	if err != nil {
+		logrus.Fatal(err)
+	}
+
+	return promoteCmd
+}
+
+func promoteArtifact(ctx context.Context, artifact api.Artifact, tags []string, options *common.Options) error {
+	log := common.Logger(artifact)
+
+	if len(tags) == 0 {
+		err := errors.New("No containerdisks to promote")
+		log.Error(err)
+		return err
+	}
+
+	repo := repository.RepositoryImpl{}
+	srcRef := path.Join(options.PromoteImageOptions.SourceRegistry, tags[0])
+	for _, tag := range tags {
+		dstRef := path.Join(options.PromoteImageOptions.TargetRegistry, tag)
+		if !options.DryRun {
+			log.Infof("Copying %s -> %s", srcRef, dstRef)
+			if err := repo.CopyImage(ctx, srcRef, dstRef, options.AllowInsecureRegistry); err != nil {
+				log.WithError(err).Error("Failed to copy image")
+				return err
+			}
+		} else {
+			log.Infof("Dry run enabled, not copying %s -> %s", srcRef, dstRef)
+		}
+
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return ctx.Err()
+		}
+	}
+
+	return nil
+}

--- a/cmd/medius/main.go
+++ b/cmd/medius/main.go
@@ -43,6 +43,7 @@ func main() {
 	rootCmd.AddCommand(imagesCmd)
 	rootCmd.AddCommand(docsCmd)
 
+	imagesCmd.AddCommand(images.NewPromoteImagesCommand(options))
 	imagesCmd.AddCommand(images.NewPublishImagesCommand(options))
 	imagesCmd.AddCommand(images.NewVerifyImagesCommand(options))
 	docsCmd.AddCommand(docs.NewPublishDocsCommand(options))

--- a/pkg/api/artifact.go
+++ b/pkg/api/artifact.go
@@ -11,17 +11,19 @@ import (
 type ArtifactTest func(ctx context.Context, vmi *v1.VirtualMachineInstance, params *ArtifactTestParams) error
 
 type ArtifactTestParams struct {
-	// Username is the username used to login into the VM
+	// Username is the username used to login into the VM.
 	Username string
-	// PrivateKey is the private key used to login into the VM
+	// PrivateKey is the private key used to login into the VM.
 	PrivateKey interface{}
 }
 
 type ArtifactResult struct {
 	// Tags contains all tags the built containerdisk was tagged with.
-	Tags []string
-	// Verified indicates if the containerdisk was verified to be bootable and that the guest is working.
-	Verified bool
+	Tags []string `json:",omitempty"`
+	// Stage is the current stage of the containerdisk
+	Stage string
+	// Err indicates if an error happened while creating, verifying or promoting a containerdisk.
+	Err string `json:",omitempty"`
 }
 
 type ArtifactDetails struct {
@@ -43,9 +45,9 @@ type Metadata struct {
 	Name string
 	// Version is the moving tag on the container image. For example "35".
 	Version string
-	// Description of the project in Markdown format
+	// Description of the project in Markdown format.
 	Description string
-	// CloudInit/Ignition Payload example
+	// CloudInit/Ignition Payload example.
 	ExampleUserDataPayload string
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This adds the cmd 'images promote', which promotes verified
containerdisks from a source to a target registry.

The cmd shares most of its logic with 'images verify', so the shared
parts were moved to common.go.

**Which issue(s) this PR fixes**:

Fixes #2

**Special notes for your reviewer**:

Merge after #18

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add cmd to promote verified containerdisks to another registry
```
