### PR TITLE
Add --no-fail flag to images [push|verify]

### DIFF
--- a/cmd/medius/common/options.go
+++ b/cmd/medius/common/options.go
@@ -28,6 +28,7 @@ type PublishDocsOptions struct {
 
 type PublishImageOptions struct {
 	ForceBuild     bool
+	NoFail         bool
 	SourceRegistry string
 	TargetRegistry string
 }
@@ -35,5 +36,6 @@ type PublishImageOptions struct {
 type VerifyImageOptions struct {
 	Registry  string
 	Namespace string
+	NoFail    bool
 	Timeout   int
 }

--- a/cmd/medius/images/push.go
+++ b/cmd/medius/images/push.go
@@ -65,11 +65,16 @@ func NewPublishImagesCommand(options *common.Options) *cobra.Command {
 			}
 
 			if err != nil {
-				logrus.Fatal(err)
+				if options.PublishImagesOptions.NoFail {
+					logrus.Warn(err)
+				} else {
+					logrus.Fatal(err)
+				}
 			}
 		},
 	}
 	publishCmd.Flags().BoolVar(&options.PublishImagesOptions.ForceBuild, "force", options.PublishImagesOptions.ForceBuild, "Force a rebuild and push")
+	publishCmd.Flags().BoolVar(&options.PublishImagesOptions.NoFail, "no-fail", options.PublishImagesOptions.NoFail, "Return success even if a worker fails")
 	publishCmd.Flags().StringVar(&options.PublishImagesOptions.SourceRegistry, "source-registry", options.PublishImagesOptions.SourceRegistry, "Registry to check if updates are needed")
 	publishCmd.Flags().StringVar(&options.PublishImagesOptions.TargetRegistry, "target-registry", options.PublishImagesOptions.TargetRegistry, "Registry to push built containerdisks to")
 

--- a/cmd/medius/images/verify.go
+++ b/cmd/medius/images/verify.go
@@ -84,12 +84,17 @@ func NewVerifyImagesCommand(options *common.Options) *cobra.Command {
 			}
 
 			if err != nil {
-				logrus.Fatal(err)
+				if options.PublishImagesOptions.NoFail {
+					logrus.Warn(err)
+				} else {
+					logrus.Fatal(err)
+				}
 			}
 		},
 	}
 	verifyCmd.Flags().StringVar(&options.VerifyImagesOptions.Registry, "registry", options.VerifyImagesOptions.Registry, "Registry that contains containerdisks to verify")
 	verifyCmd.Flags().StringVar(&options.VerifyImagesOptions.Namespace, "namespace", options.VerifyImagesOptions.Namespace, "Namespace to run verify in")
+	verifyCmd.Flags().BoolVar(&options.VerifyImagesOptions.NoFail, "no-fail", options.VerifyImagesOptions.NoFail, "Return success even if a worker fails")
 	verifyCmd.Flags().IntVar(&options.VerifyImagesOptions.Timeout, "timeout", options.VerifyImagesOptions.Timeout, "Maximum seconds to wait for VM to be running")
 	verifyCmd.Flags().AddGoFlagSet(kvirtcli.FlagSet())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

With this flag exit code 0 is returned even if a worker fails.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add --no-fail flag to 'images push' and 'images verify'
```
