### PR TITLE
Increase wait timeout for kubevirtci

### DIFF
--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -33,7 +33,7 @@ function kubevirtci::up() {
   ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-operator.yaml"
   ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-cr.yaml"
   echo "waiting for kubevirt to become ready, this can take a few minutes..."
-  ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=5m
+  ${_kubectl} -n kubevirt wait kv kubevirt --for condition=Available --timeout=15m
 }
 
 function kubevirtci::down() {


### PR DESCRIPTION
**What this PR does / why we need it**:

Give CI clusters more time to come up.
Fixes issues like in https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-containerdisks-push-nightly/1518611121794191360.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
