### PR TITLE
Don't add shasum tags to ubuntu

### DIFF
--- a/artifacts/ubuntu/ubuntu.go
+++ b/artifacts/ubuntu/ubuntu.go
@@ -47,10 +47,9 @@ func (u *ubuntu) Inspect() (*api.ArtifactDetails, error) {
 	}
 	if checksum, exists := checksums[u.Variant]; exists {
 		return &api.ArtifactDetails{
-			SHA256Sum:            checksum,
-			DownloadURL:          baseURL + u.Variant,
-			Compression:          u.Compression,
-			AdditionalUniqueTags: []string{checksum},
+			SHA256Sum:   checksum,
+			DownloadURL: baseURL + u.Variant,
+			Compression: u.Compression,
 		}, nil
 	}
 	return nil, fmt.Errorf("file %q does not exist in the SHA256SUMS file: %v", u.Variant, err)

--- a/artifacts/ubuntu/ubuntu_test.go
+++ b/artifacts/ubuntu/ubuntu_test.go
@@ -30,9 +30,8 @@ func Test_Inspect(t *testing.T) {
 			mockFile:      "testdata/SHA256SUM",
 		}, want: want{
 			artifactDetails: &api.ArtifactDetails{
-				SHA256Sum:            "de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd",
-				DownloadURL:          "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img",
-				AdditionalUniqueTags: []string{"de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd"},
+				SHA256Sum:   "de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd",
+				DownloadURL: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img",
 			},
 			metadata: &api.Metadata{
 				Name:                   "ubuntu",


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix a copy-past error when copying from the rhcos atrifact. We don't need the shasum as tag in this case. For rhcos we have a special use-case for these tags.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
