### PR TITLE
Add fedora:36 to the artifacts

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -20,6 +20,10 @@ type Entry struct {
 var Registry = []Entry{
 	{
 		Artifact:   fedora.New("35"),
+		UseForDocs: false,
+	},
+	{
+		Artifact:   fedora.New("36"),
 		UseForDocs: true,
 	},
 	{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Add fedora:36 to the artifacts

The UseForDocs flags are also updated, so the latest supported artifact
of each distribution is used for documentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add fedora:36 to the artifacts
```
