### PR TITLE
Update UseForDocs flags of artifacts

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -40,7 +40,7 @@ var Registry = []Entry{
 	},
 	{
 		Artifact:   rhcosprerelease.New("latest-4.11"),
-		UseForDocs: true,
+		UseForDocs: false,
 	},
 	{
 		Artifact:   rhcosprerelease.New("latest"),
@@ -48,18 +48,19 @@ var Registry = []Entry{
 	},
 	{
 		Artifact:   centos.New("8.4"),
-		UseForDocs: true,
-	},
-	{
-		Artifact:   centos.New("7-2009"),
 		UseForDocs: false,
 	},
 	{
-		Artifact: centosstream.New("9"),
+		Artifact:   centos.New("7-2009"),
+		UseForDocs: true,
+	},
+	{
+		Artifact:   centosstream.New("9"),
+		UseForDocs: true,
 	},
 	{
 		Artifact:   centosstream.New("8"),
-		UseForDocs: true,
+		UseForDocs: false,
 	},
 	{
 		Artifact:   ubuntu.New("22.04"),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

The UseForDocs flags are updated, so the latest supported artifact
of each distribution is used for documentation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
