### PR TITLE
Add UseForLatest attribute to common.Registry entries

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -14,6 +14,7 @@ import (
 type Entry struct {
 	Artifact           api.Artifact
 	UseForDocs         bool
+	UseForLatest       bool
 	SkipWhenNotFocused bool
 }
 
@@ -23,8 +24,9 @@ var Registry = []Entry{
 		UseForDocs: false,
 	},
 	{
-		Artifact:   fedora.New("36"),
-		UseForDocs: true,
+		Artifact:     fedora.New("36"),
+		UseForDocs:   true,
+		UseForLatest: true,
 	},
 	{
 		Artifact:   rhcos.New("4.9"),

--- a/cmd/medius/images/promote.go
+++ b/cmd/medius/images/promote.go
@@ -27,20 +27,21 @@ func NewPromoteImagesCommand(options *common.Options) *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			resultsChan, err := spawnWorkers(cmd.Context(), options, func(a api.Artifact) (*api.ArtifactResult, error) {
-				r, ok := results[a.Metadata().Describe()]
+			resultsChan, err := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
+				description := e.Artifact.Metadata().Describe()
+				r, ok := results[description]
 				if !ok {
 					return nil, nil
 				}
 				if r.Err != "" {
-					return nil, fmt.Errorf("Artifact %s failed in stage %s: %s", a.Metadata().Describe(), r.Stage, r.Err)
+					return nil, fmt.Errorf("Artifact %s failed in stage %s: %s", description, r.Stage, r.Err)
 				}
 				if r.Stage != StageVerify {
 					return nil, nil
 				}
 
 				errString := ""
-				err := promoteArtifact(cmd.Context(), a, r.Tags, options)
+				err := promoteArtifact(cmd.Context(), e.Artifact, r.Tags, options)
 				if err != nil {
 					errString = err.Error()
 				}

--- a/cmd/medius/images/verify.go
+++ b/cmd/medius/images/verify.go
@@ -51,20 +51,21 @@ func NewVerifyImagesCommand(options *common.Options) *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			resultsChan, err := spawnWorkers(cmd.Context(), options, func(a api.Artifact) (*api.ArtifactResult, error) {
-				r, ok := results[a.Metadata().Describe()]
+			resultsChan, err := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
+				description := e.Artifact.Metadata().Describe()
+				r, ok := results[description]
 				if !ok {
 					return nil, nil
 				}
 				if r.Err != "" {
-					return nil, fmt.Errorf("Artifact %s failed in stage %s: %s", a.Metadata().Describe(), r.Stage, r.Err)
+					return nil, fmt.Errorf("Artifact %s failed in stage %s: %s", description, r.Stage, r.Err)
 				}
 				if r.Stage != StagePush {
 					return nil, nil
 				}
 
 				errString := ""
-				err := verifyArtifact(cmd.Context(), a, r, options, client)
+				err := verifyArtifact(cmd.Context(), e.Artifact, r, options, client)
 				if err != nil {
 					errString = err.Error()
 				}


### PR DESCRIPTION
**What this PR does / why we need it**:

This attribute allows to specify if the artifact of the entry should
be additionally tagged with ':latest'.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add UseForLatest attribute to common.Registry entries
```
