### PR TITLE
Filter out Fedora versions lower than 35

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -3,6 +3,7 @@ package fedora
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -36,6 +37,8 @@ type fedoraGatherer struct {
 	Variant string
 	getter  http.Getter
 }
+
+const minimumVersion = 35
 
 var description string = `<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Fedora_logo.svg/240px-Fedora_logo.svg.png" alt="drawing" width="15"/> Fedora [Cloud](https://alt.fedoraproject.org/cloud/) images for KubeVirt.
 <br />
@@ -133,7 +136,9 @@ func (f *fedora) releaseMatches(release *Release) bool {
 }
 
 func (f *fedoraGatherer) releaseMatches(release *Release) bool {
-	return release.Arch == f.Arch &&
+	version, err := strconv.Atoi(release.Version)
+	return err == nil && version >= minimumVersion &&
+		release.Arch == f.Arch &&
 		release.Variant == f.Variant &&
 		strings.HasSuffix(release.Link, "qcow2")
 }

--- a/artifacts/fedora/fedora_test.go
+++ b/artifacts/fedora/fedora_test.go
@@ -120,18 +120,6 @@ func Test_Gather(t *testing.T) {
 						Variant: "Cloud",
 						getter:  &http.HTTPGetter{},
 					},
-					&fedora{
-						Version: "34",
-						Arch:    "x86_64",
-						Variant: "Cloud",
-						getter:  &http.HTTPGetter{},
-					},
-					&fedora{
-						Version: "33",
-						Arch:    "x86_64",
-						Variant: "Cloud",
-						getter:  &http.HTTPGetter{},
-					},
 				},
 			},
 			wantErr: false,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

These versions do not support UEFI and additionally Fedora 33 does not
come with the qemu-guest-agent installed. Because these versions are EOL
they are filtered out instead of adding workarounds.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
