### PR TITLE
Update kubevirtci default to 1.25

### DIFF
--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -5,7 +5,7 @@ set -e
 KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://storage.googleapis.com/kubevirt-prow/release/kubevirt/kubevirtci/latest)}
 export KUBEVIRTCI_TAG
 
-export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.23}
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.25}
 export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-1}
 export KUBEVIRT_MEMORY_SIZE=${KUBEVIRT_MEMORY_SIZE:-4096M}
 export KUBEVIRT_DEPLOY_CDI="true"


### PR DESCRIPTION
**What this PR does / why we need it**:
The k8s-1.23 kubevirtci provider no longer exists - update the default to k8s-1.25

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #
Issue with the periodic nightly push - k8s-1.23 is not found
https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/logs/periodic-containerdisks-push-nightly/1625676304881815552#1:build-log.txt%3A140


**Special notes for your reviewer**:
/cc @0xFelix @lyarwood 


**Release note**:
```release-note
NONE
```
