### PR TITLE
Fix failing periodic CI runs 

### DIFF
--- a/cmd/medius/images/verify.go
+++ b/cmd/medius/images/verify.go
@@ -86,7 +86,7 @@ func NewVerifyImagesCommand(options *common.Options) *cobra.Command {
 			}
 
 			if err != nil {
-				if options.PublishImagesOptions.NoFail {
+				if options.VerifyImagesOptions.NoFail {
 					logrus.Warn(err)
 				} else {
 					logrus.Fatal(err)

--- a/pkg/tests/common.go
+++ b/pkg/tests/common.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	maxRetries    = 10
+	maxRetries    = 30
 	retryDuration = 10 * time.Second
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This fixes failing periodic CI runs by:

- increasing the maximum retries to 30, VMs have up to 300 seconds to boot before the test fails
- evaluating the correct field for passing `no-fail` to `medius images verify`

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
