### PR TITLE
Change the user name in the doc to `myuser`

### DIFF
--- a/pkg/docs/data/cloudinit.tpl
+++ b/pkg/docs/data/cloudinit.tpl
@@ -1,6 +1,6 @@
 #cloud-config
 users:
-  - name: {{ or .Username "admin" }}
+  - name: {{ or .Username "myuser" }}
     sudo: ALL=(ALL) NOPASSWD:ALL
     ssh_authorized_keys:
       {{- range .AuthorizedKeys}}


### PR DESCRIPTION
I was testing ubuntu containerdisk image with the example [in the doc](https://quay.io/repository/containerdisks/ubuntu), and I could not ssh into the vm with error `ssh: handshake failed: ssh: unable to authenticate, attempted methods [none publickey], no supported methods remain`. 

After some investigations it turns out the user `admin` cannot be added by cloud-init, since the name `admin` conflicts with predefined user group `admin` in the OS. 

This PR changes the user name to `myuser` to avoid conflict with predefined names. 


![image](https://user-images.githubusercontent.com/11867646/232788326-2ec6ab13-964b-4001-bc76-1ffeac6ba5e1.png)


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
