### PR TITLE
fix: Use a reference to the registry in gatherArtifacts

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -109,14 +109,14 @@ var staticRegistry = []Entry{
 	},
 }
 
-func gatherArtifacts(registry []Entry, gatherers []api.ArtifactsGatherer) {
+func gatherArtifacts(registry *[]Entry, gatherers []api.ArtifactsGatherer) {
 	for _, gatherer := range gatherers {
 		artifacts, err := gatherer.Gather()
 		if err != nil {
 			logrus.Warn("Failed to gather artifacts", err)
 		} else {
 			for i := range artifacts {
-				registry = append(registry, Entry{
+				*registry = append(*registry, Entry{
 					Artifact:     artifacts[i],
 					UseForDocs:   i == 0,
 					UseForLatest: i == 0,
@@ -131,7 +131,7 @@ func NewRegistry() []Entry {
 	copy(registry, staticRegistry)
 
 	gatherers := []api.ArtifactsGatherer{fedora.NewGatherer()}
-	gatherArtifacts(registry, gatherers)
+	gatherArtifacts(&registry, gatherers)
 
 	return registry
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This changes gatherArtifactes to use a pointer the the slice it should update. Without this the dynamically gathered artifacts were lost as the variable poiting to the original slice that was passed in was not updated.

This was introduced accidentally during refactorings.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
