### PR TITLE
Return error when focus did not match and update pipeline.sh to use cirros:6.1

### DIFF
--- a/cmd/medius/docs/docs.go
+++ b/cmd/medius/docs/docs.go
@@ -44,6 +44,7 @@ func NewPublishDocsCommand(options *common.Options) *cobra.Command {
 
 func run(options *common.Options) error {
 	success := true
+	focusMatched := false
 
 	quayOrg, err := getQuayOrg(options.PublishDocsOptions.Registry)
 	if err != nil {
@@ -57,6 +58,7 @@ func run(options *common.Options) error {
 			continue
 		}
 
+		focusMatched = true
 		log := common.Logger(p.Artifact)
 		name := p.Artifact.Metadata().Name
 
@@ -74,6 +76,10 @@ func run(options *common.Options) error {
 				log.Errorf("error marshaling example for for %q: %v", name, err)
 			}
 		}
+	}
+
+	if !focusMatched {
+		return fmt.Errorf("no artifact was processed, focus '%s' did not match", options.Focus)
 	}
 
 	if !success {

--- a/cmd/medius/images/promote.go
+++ b/cmd/medius/images/promote.go
@@ -27,7 +27,7 @@ func NewPromoteImagesCommand(options *common.Options) *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			resultsChan, workerErr := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
+			focusMatched, resultsChan, workerErr := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
 				description := e.Artifact.Metadata().Describe()
 				r, ok := results[description]
 				if !ok {
@@ -55,6 +55,10 @@ func NewPromoteImagesCommand(options *common.Options) *cobra.Command {
 
 			for result := range resultsChan {
 				results[result.Key] = result.Value
+			}
+
+			if !focusMatched {
+				logrus.Fatalf("no artifact was processed, focus '%s' did not match", options.Focus)
 			}
 
 			if !options.DryRun {

--- a/cmd/medius/images/push.go
+++ b/cmd/medius/images/push.go
@@ -43,7 +43,7 @@ func NewPublishImagesCommand(options *common.Options) *cobra.Command {
 				options.PublishImagesOptions.TargetRegistry = options.PublishImagesOptions.SourceRegistry
 			}
 
-			resultsChan, workerErr := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
+			focusMatched, resultsChan, workerErr := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
 				errString := ""
 
 				b := buildAndPublish{
@@ -72,6 +72,10 @@ func NewPublishImagesCommand(options *common.Options) *cobra.Command {
 			results := map[string]api.ArtifactResult{}
 			for result := range resultsChan {
 				results[result.Key] = result.Value
+			}
+
+			if !focusMatched {
+				logrus.Fatalf("no artifact was processed, focus '%s' did not match", options.Focus)
 			}
 
 			if !options.DryRun {

--- a/cmd/medius/images/verify.go
+++ b/cmd/medius/images/verify.go
@@ -51,7 +51,7 @@ func NewVerifyImagesCommand(options *common.Options) *cobra.Command {
 				logrus.Fatal(err)
 			}
 
-			resultsChan, workerErr := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
+			focusMatched, resultsChan, workerErr := spawnWorkers(cmd.Context(), options, func(e *common.Entry) (*api.ArtifactResult, error) {
 				description := e.Artifact.Metadata().Describe()
 				r, ok := results[description]
 				if !ok {
@@ -79,6 +79,10 @@ func NewVerifyImagesCommand(options *common.Options) *cobra.Command {
 
 			for result := range resultsChan {
 				results[result.Key] = result.Value
+			}
+
+			if !focusMatched {
+				logrus.Fatalf("no artifact was processed, focus '%s' did not match", options.Focus)
 			}
 
 			if err := writeResultsFile(options.ImagesOptions.ResultsFile, results); err != nil {

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -7,8 +7,8 @@ make cluster-up
 
 registry="$(./hack/kubevirtci.sh registry)"
 kubeconfig="$(./hack/kubevirtci.sh kubeconfig)"
-./bin/medius images push --force --focus=cirros:5.2 --no-fail --dry-run=false --source-registry=${registry} --insecure-skip-tls --workers 3
-./bin/medius images verify --focus=cirros:5.2 --no-fail --dry-run=false --kubeconfig=${kubeconfig} --registry="registry:5000" --insecure-skip-tls --workers 3
-./bin/medius images promote --focus=cirros:5.2 --dry-run=true --source-registry=${registry} --insecure-skip-tls --workers 3
+./bin/medius images push --force --focus=cirros:6.1 --no-fail --dry-run=false --source-registry=${registry} --insecure-skip-tls --workers 3
+./bin/medius images verify --focus=cirros:6.1 --no-fail --dry-run=false --kubeconfig=${kubeconfig} --registry="registry:5000" --insecure-skip-tls --workers 3
+./bin/medius images promote --focus=cirros:6.1 --dry-run=true --source-registry=${registry} --insecure-skip-tls --workers 3
 
 make cluster-down


### PR DESCRIPTION
**What this PR does / why we need it**:

This changes medius to return an error if no artifact was processed.
Previously no error was returned which allowed focussing on not present
artifacts.

cirros:5.2 does no longer exist, use cirros:6.1 in `pipeline.sh` instead.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
