### PR TITLE
fix(pipeline.sh): Drop --workers flag

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -8,8 +8,8 @@ make cluster-up
 FOCUS=${FOCUS:-cirros:6.1}
 registry="$(./hack/kubevirtci.sh registry)"
 kubeconfig="$(./hack/kubevirtci.sh kubeconfig)"
-./bin/medius images push --force --focus="${FOCUS}" --no-fail --dry-run=false --source-registry="${registry}" --insecure-skip-tls --workers 3
-./bin/medius images verify --focus="${FOCUS}" --no-fail --dry-run=false --kubeconfig="${kubeconfig}" --registry="registry:5000" --insecure-skip-tls --workers 3
-./bin/medius images promote --focus="${FOCUS}" --dry-run=true --source-registry="${registry}" --insecure-skip-tls --workers 3
+./bin/medius images push --force --focus="${FOCUS}" --no-fail --dry-run=false --source-registry="${registry}" --insecure-skip-tls
+./bin/medius images verify --focus="${FOCUS}" --no-fail --dry-run=false --kubeconfig="${kubeconfig}" --registry="registry:5000" --insecure-skip-tls
+./bin/medius images promote --focus="${FOCUS}" --dry-run=true --source-registry="${registry}" --insecure-skip-tls
 
 make cluster-down


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

By dropping the workers flag the pipeline is able to run in more constrained environments by running just one parallel worker.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
