### PR TITLE
fix: Log correct error when logging worker error

### DIFF
--- a/cmd/medius/images/common.go
+++ b/cmd/medius/images/common.go
@@ -51,7 +51,7 @@ func spawnWorkers(ctx context.Context, o *common.Options,
 					}
 				}
 				if workerErr != nil && !errors.Is(workerErr, context.Canceled) {
-					common.Logger(e.Artifact).Error(err)
+					common.Logger(e.Artifact).Error(workerErr)
 					errChan <- workerErr
 				}
 				if errors.Is(ctx.Err(), context.Canceled) {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Log correct error when logging worker error.

This regression was introduced in
84225e0ec09e1e1889b88e53e7f07698e0b26922 when renaming variables.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
