### PR TITLE
chore: stop using deprecated cdi-insecure-registries configmap

### DIFF
--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -22,7 +22,7 @@ function kubevirtci::up() {
   KUBECONFIG=$(kubevirtci::kubeconfig)
   export KUBECONFIG
   echo "adding kubevirtci registry to cdi-insecure-registries"
-  ${_kubectl} patch configmap cdi-insecure-registries -n cdi --type merge -p '{"data":{"kubevirtci": "registry:5000"}}'
+  ${_kubectl} patch cdi/cdi --type merge -p '{"spec": {"config": {"insecureRegistries": ["registry:5000"]}}}'
   echo "installing kubevirt..."
   LATEST=$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)
   ${_kubectl} apply -f "https://github.com/kubevirt/kubevirt/releases/download/${LATEST}/kubevirt-operator.yaml"


### PR DESCRIPTION
**What this PR does / why we need it**:

https://github.com/kubevirt/containerized-data-importer/pull/2723

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
