### PR TITLE
cleanup: Drop labels from containerdisks

### DIFF
--- a/artifacts/centos/centos.go
+++ b/artifacts/centos/centos.go
@@ -22,11 +22,11 @@ const description = `<img src="https://upload.wikimedia.org/wikipedia/commons/th
 Visit [centos.org](https://www.centos.org/) to learn more about the CentOS project.`
 
 type centos struct {
-	Version          string
-	Variant          string
-	getter           http.Getter
-	Arch             string
-	AdditionalLabels map[string]string
+	Version      string
+	Variant      string
+	getter       http.Getter
+	Arch         string
+	EnvVariables map[string]string
 }
 
 func (c *centos) Metadata() *api.Metadata {
@@ -37,7 +37,7 @@ func (c *centos) Metadata() *api.Metadata {
 		ExampleUserData: docs.UserData{
 			Username: "centos",
 		},
-		AdditionalLabels: c.AdditionalLabels,
+		EnvVariables: c.EnvVariables,
 	}
 }
 
@@ -147,12 +147,12 @@ func (c *centos) Tests() []api.ArtifactTest {
 }
 
 // New accepts CentOS 7 and 8 versions. Example patterns are 7-2111, 7-2009, 8.3, 8.4, ...
-func New(release string, additionalLabels map[string]string) *centos {
+func New(release string, envVariables map[string]string) *centos {
 	return &centos{
-		Version:          release,
-		Variant:          "GenericCloud",
-		Arch:             "x86_64",
-		getter:           &http.HTTPGetter{},
-		AdditionalLabels: additionalLabels,
+		Version:      release,
+		Variant:      "GenericCloud",
+		Arch:         "x86_64",
+		getter:       &http.HTTPGetter{},
+		EnvVariables: envVariables,
 	}
 }

--- a/artifacts/centos/centos_test.go
+++ b/artifacts/centos/centos_test.go
@@ -6,17 +6,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/api/instancetype"
-
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/testutil"
 )
 
 var _ = Describe("Centos", func() {
 	DescribeTable("Inspect should be able to parse checksum files",
-		func(release, mockFile string, details *api.ArtifactDetails, additionalLabels map[string]string, metadata *api.Metadata) {
-			c := New(release, additionalLabels)
+		func(release, mockFile string, details *api.ArtifactDetails, envVariables map[string]string, metadata *api.Metadata) {
+			c := New(release, envVariables)
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
@@ -31,7 +30,7 @@ var _ = Describe("Centos", func() {
 				AdditionalUniqueTags: []string{"8.4.2105-20210603.0", "8.4.2105"},
 			},
 			map[string]string{
-				"test-label": "test-value",
+				"TEST_ENV_VAR": "test-value",
 			},
 			&api.Metadata{
 				Name:        "centos",
@@ -40,8 +39,8 @@ var _ = Describe("Centos", func() {
 				ExampleUserData: docs.UserData{
 					Username: "centos",
 				},
-				AdditionalLabels: map[string]string{
-					"test-label": "test-value",
+				EnvVariables: map[string]string{
+					"TEST_ENV_VAR": "test-value",
 				},
 			},
 		),
@@ -53,7 +52,7 @@ var _ = Describe("Centos", func() {
 				AdditionalUniqueTags: []string{"8.3.2011-20201204.2", "8.3.2011"},
 			},
 			map[string]string{
-				"test-label": "test-value",
+				"TEST_ENV_VAR": "test-value",
 			},
 			&api.Metadata{
 				Name:        "centos",
@@ -62,8 +61,8 @@ var _ = Describe("Centos", func() {
 				ExampleUserData: docs.UserData{
 					Username: "centos",
 				},
-				AdditionalLabels: map[string]string{
-					"test-label": "test-value",
+				EnvVariables: map[string]string{
+					"TEST_ENV_VAR": "test-value",
 				},
 			},
 		),
@@ -73,8 +72,8 @@ var _ = Describe("Centos", func() {
 				DownloadURL: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-2009.qcow2",
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "centos.7",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "centos.7",
 			},
 			&api.Metadata{
 				Name:        "centos",
@@ -83,9 +82,9 @@ var _ = Describe("Centos", func() {
 				ExampleUserData: docs.UserData{
 					Username: "centos",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "centos.7",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "centos.7",
 				},
 			},
 		),
@@ -95,8 +94,8 @@ var _ = Describe("Centos", func() {
 				DownloadURL: "https://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud-1809.qcow2",
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "centos.7",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "centos.7",
 			},
 			&api.Metadata{
 				Name:        "centos",
@@ -105,9 +104,9 @@ var _ = Describe("Centos", func() {
 				ExampleUserData: docs.UserData{
 					Username: "centos",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "centos.7",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "centos.7",
 				},
 			},
 		),

--- a/artifacts/centosstream/centos-stream.go
+++ b/artifacts/centosstream/centos-stream.go
@@ -22,20 +22,20 @@ const description = `<img src="https://upload.wikimedia.org/wikipedia/commons/th
 Visit [centos.org](https://www.centos.org/) to learn more about the CentOS project.`
 
 type centos struct {
-	Version          string
-	Variant          string
-	getter           http.Getter
-	Arch             string
-	ExampleUserData  *docs.UserData
-	AdditionalLabels map[string]string
+	Version         string
+	Variant         string
+	getter          http.Getter
+	Arch            string
+	ExampleUserData *docs.UserData
+	EnvVariables    map[string]string
 }
 
 func (c *centos) Metadata() *api.Metadata {
 	metadata := &api.Metadata{
-		Name:             "centos-stream",
-		Version:          c.Version,
-		Description:      description,
-		AdditionalLabels: c.AdditionalLabels,
+		Name:         "centos-stream",
+		Version:      c.Version,
+		Description:  description,
+		EnvVariables: c.EnvVariables,
 	}
 
 	if c.ExampleUserData != nil {
@@ -116,13 +116,13 @@ func (c *centos) Tests() []api.ArtifactTest {
 }
 
 // New accepts CentOS Stream 8 and 9 versions.
-func New(release string, exampleUserData *docs.UserData, additionalLabels map[string]string) *centos {
+func New(release string, exampleUserData *docs.UserData, envVariables map[string]string) *centos {
 	return &centos{
-		Version:          release,
-		Arch:             "x86_64",
-		Variant:          "GenericCloud",
-		getter:           &http.HTTPGetter{},
-		ExampleUserData:  exampleUserData,
-		AdditionalLabels: additionalLabels,
+		Version:         release,
+		Arch:            "x86_64",
+		Variant:         "GenericCloud",
+		getter:          &http.HTTPGetter{},
+		ExampleUserData: exampleUserData,
+		EnvVariables:    envVariables,
 	}
 }

--- a/artifacts/centosstream/centos-stream_test.go
+++ b/artifacts/centosstream/centos-stream_test.go
@@ -6,9 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/api/instancetype"
-
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/testutil"
 )
@@ -16,8 +15,8 @@ import (
 var _ = Describe("CentosStream", func() {
 	DescribeTable("Inspect should be able to parse checksum files",
 		func(release, mockFile string, details *api.ArtifactDetails,
-			exampleUserData *docs.UserData, additionalLabels map[string]string, metadata *api.Metadata) {
-			c := New(release, exampleUserData, additionalLabels)
+			exampleUserData *docs.UserData, envVariables map[string]string, metadata *api.Metadata) {
+			c := New(release, exampleUserData, envVariables)
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
@@ -34,8 +33,8 @@ var _ = Describe("CentosStream", func() {
 				Username: "centos",
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "centos.stream8",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "centos.stream8",
 			},
 			&api.Metadata{
 				Name:        "centos-stream",
@@ -44,9 +43,9 @@ var _ = Describe("CentosStream", func() {
 				ExampleUserData: docs.UserData{
 					Username: "centos",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "centos.stream8",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "centos.stream8",
 				},
 			},
 		),
@@ -60,8 +59,8 @@ var _ = Describe("CentosStream", func() {
 				Username: "cloud-user",
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "centos.stream9",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "centos.stream9",
 			},
 			&api.Metadata{
 				Name:        "centos-stream",
@@ -70,9 +69,9 @@ var _ = Describe("CentosStream", func() {
 				ExampleUserData: docs.UserData{
 					Username: "cloud-user",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "centos.stream9",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "centos.stream9",
 				},
 			},
 		),

--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -7,9 +7,9 @@ import (
 	"strings"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/api/instancetype"
 
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/pkg/http"
 	"kubevirt.io/containerdisks/pkg/tests"
@@ -28,11 +28,11 @@ type Release struct {
 }
 
 type fedora struct {
-	Version          string
-	Arch             string
-	Variant          string
-	getter           http.Getter
-	AdditionalLabels map[string]string
+	Version      string
+	Arch         string
+	Variant      string
+	getter       http.Getter
+	EnvVariables map[string]string
 }
 
 type fedoraGatherer struct {
@@ -57,7 +57,7 @@ func (f *fedora) Metadata() *api.Metadata {
 		ExampleUserData: docs.UserData{
 			Username: "fedora",
 		},
-		AdditionalLabels: f.AdditionalLabels,
+		EnvVariables: f.EnvVariables,
 	}
 }
 
@@ -118,8 +118,8 @@ func (f *fedoraGatherer) Gather() ([]api.Artifact, error) {
 				New(
 					release.Version,
 					map[string]string{
-						instancetype.DefaultInstancetypeLabel: "u1.small",
-						instancetype.DefaultPreferenceLabel:   "fedora",
+						common.DefaultInstancetypeEnv: "u1.small",
+						common.DefaultPreferenceEnv:   "fedora",
 					},
 				),
 			)
@@ -158,13 +158,13 @@ func (f *fedoraGatherer) releaseMatches(release *Release) bool {
 		strings.HasSuffix(release.Link, "qcow2")
 }
 
-func New(release string, additionalLabels map[string]string) *fedora {
+func New(release string, envVariables map[string]string) *fedora {
 	return &fedora{
-		Version:          release,
-		Arch:             "x86_64",
-		Variant:          "Cloud",
-		getter:           &http.HTTPGetter{},
-		AdditionalLabels: additionalLabels,
+		Version:      release,
+		Arch:         "x86_64",
+		Variant:      "Cloud",
+		getter:       &http.HTTPGetter{},
+		EnvVariables: envVariables,
 	}
 }
 

--- a/artifacts/fedora/fedora_test.go
+++ b/artifacts/fedora/fedora_test.go
@@ -6,9 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/api/instancetype"
-
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/pkg/http"
 	"kubevirt.io/containerdisks/testutil"
@@ -16,8 +15,8 @@ import (
 
 var _ = Describe("Fedora", func() {
 	DescribeTable("Inspect should be able to parse releases files",
-		func(release, mockFile string, details *api.ArtifactDetails, additionalLabels map[string]string, metadata *api.Metadata) {
-			c := New(release, additionalLabels)
+		func(release, mockFile string, details *api.ArtifactDetails, envVariables map[string]string, metadata *api.Metadata) {
+			c := New(release, envVariables)
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
@@ -31,8 +30,8 @@ var _ = Describe("Fedora", func() {
 				AdditionalUniqueTags: []string{"35-1.2"},
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "fedora",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "fedora",
 			},
 			&api.Metadata{
 				Name:        "fedora",
@@ -41,9 +40,9 @@ var _ = Describe("Fedora", func() {
 				ExampleUserData: docs.UserData{
 					Username: "fedora",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "fedora",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "fedora",
 				},
 			},
 		),
@@ -54,8 +53,8 @@ var _ = Describe("Fedora", func() {
 				AdditionalUniqueTags: []string{"34-1.2"},
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "fedora",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "fedora",
 			},
 			&api.Metadata{
 				Name:        "fedora",
@@ -64,9 +63,9 @@ var _ = Describe("Fedora", func() {
 				ExampleUserData: docs.UserData{
 					Username: "fedora",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "fedora",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "fedora",
 				},
 			},
 		),
@@ -79,9 +78,9 @@ var _ = Describe("Fedora", func() {
 				Arch:    "x86_64",
 				Variant: "Cloud",
 				getter:  &http.HTTPGetter{},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "fedora",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "fedora",
 				},
 			},
 			&fedora{
@@ -89,9 +88,9 @@ var _ = Describe("Fedora", func() {
 				Arch:    "x86_64",
 				Variant: "Cloud",
 				getter:  &http.HTTPGetter{},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "fedora",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "fedora",
 				},
 			},
 		}

--- a/artifacts/ubuntu/ubuntu.go
+++ b/artifacts/ubuntu/ubuntu.go
@@ -14,12 +14,12 @@ import (
 )
 
 type ubuntu struct {
-	Version          string
-	Variant          string
-	getter           http.Getter
-	Arch             string
-	Compression      string
-	AdditionalLabels map[string]string
+	Version      string
+	Variant      string
+	getter       http.Getter
+	Arch         string
+	Compression  string
+	EnvVariables map[string]string
 }
 
 const description = `Ubuntu images for KubeVirt.
@@ -35,7 +35,7 @@ func (u *ubuntu) Metadata() *api.Metadata {
 		ExampleUserData: docs.UserData{
 			Username: "ubuntu",
 		},
-		AdditionalLabels: u.AdditionalLabels,
+		EnvVariables: u.EnvVariables,
 	}
 }
 
@@ -79,12 +79,12 @@ func (u *ubuntu) Tests() []api.ArtifactTest {
 	}
 }
 
-func New(release string, additionalLabels map[string]string) *ubuntu {
+func New(release string, envVariables map[string]string) *ubuntu {
 	return &ubuntu{
-		Version:          release,
-		Arch:             "x86_64",
-		Variant:          fmt.Sprintf("ubuntu-%v-server-cloudimg-amd64.img", release),
-		getter:           &http.HTTPGetter{},
-		AdditionalLabels: additionalLabels,
+		Version:      release,
+		Arch:         "x86_64",
+		Variant:      fmt.Sprintf("ubuntu-%v-server-cloudimg-amd64.img", release),
+		getter:       &http.HTTPGetter{},
+		EnvVariables: envVariables,
 	}
 }

--- a/artifacts/ubuntu/ubuntu_test.go
+++ b/artifacts/ubuntu/ubuntu_test.go
@@ -6,17 +6,16 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
-	"kubevirt.io/api/instancetype"
-
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/testutil"
 )
 
 var _ = Describe("Ubuntu", func() {
 	DescribeTable("Inspect should be able to parse checksum files",
-		func(release, mockFile string, details *api.ArtifactDetails, additionalLabels map[string]string, metadata *api.Metadata) {
-			c := New(release, additionalLabels)
+		func(release, mockFile string, details *api.ArtifactDetails, envVariables map[string]string, metadata *api.Metadata) {
+			c := New(release, envVariables)
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
@@ -29,8 +28,8 @@ var _ = Describe("Ubuntu", func() {
 				DownloadURL: "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img",
 			},
 			map[string]string{
-				instancetype.DefaultInstancetypeLabel: "u1.small",
-				instancetype.DefaultPreferenceLabel:   "ubuntu",
+				common.DefaultInstancetypeEnv: "u1.small",
+				common.DefaultPreferenceEnv:   "ubuntu",
 			},
 			&api.Metadata{
 				Name:        "ubuntu",
@@ -39,9 +38,9 @@ var _ = Describe("Ubuntu", func() {
 				ExampleUserData: docs.UserData{
 					Username: "ubuntu",
 				},
-				AdditionalLabels: map[string]string{
-					instancetype.DefaultInstancetypeLabel: "u1.small",
-					instancetype.DefaultPreferenceLabel:   "ubuntu",
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.small",
+					common.DefaultPreferenceEnv:   "ubuntu",
 				},
 			},
 		),

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -4,7 +4,6 @@ import (
 	"strings"
 
 	"github.com/sirupsen/logrus"
-	"kubevirt.io/api/instancetype"
 
 	"kubevirt.io/containerdisks/artifacts/centos"
 	"kubevirt.io/containerdisks/artifacts/centosstream"
@@ -12,6 +11,7 @@ import (
 	"kubevirt.io/containerdisks/artifacts/generic"
 	"kubevirt.io/containerdisks/artifacts/ubuntu"
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 )
 
@@ -30,7 +30,7 @@ var staticRegistry = []Entry{
 	{
 		Artifact: centos.New(
 			"7-2009",
-			defaultLabels("u1.small", "centos.7"),
+			defaultEnvVariables("u1.small", "centos.7"),
 		),
 		UseForDocs: true,
 	},
@@ -40,7 +40,7 @@ var staticRegistry = []Entry{
 			&docs.UserData{
 				Username: "cloud-user",
 			},
-			defaultLabels("u1.small", "centos.stream9"),
+			defaultEnvVariables("u1.small", "centos.stream9"),
 		),
 		UseForDocs: true,
 	},
@@ -50,28 +50,28 @@ var staticRegistry = []Entry{
 			&docs.UserData{
 				Username: "centos",
 			},
-			defaultLabels("u1.small", "centos.stream8"),
+			defaultEnvVariables("u1.small", "centos.stream8"),
 		),
 		UseForDocs: false,
 	},
 	{
 		Artifact: ubuntu.New(
 			"22.04",
-			defaultLabels("u1.small", "ubuntu"),
+			defaultEnvVariables("u1.small", "ubuntu"),
 		),
 		UseForDocs: true,
 	},
 	{
 		Artifact: ubuntu.New(
 			"20.04",
-			defaultLabels("u1.small", "ubuntu"),
+			defaultEnvVariables("u1.small", "ubuntu"),
 		),
 		UseForDocs: false,
 	},
 	{
 		Artifact: ubuntu.New(
 			"18.04",
-			defaultLabels("u1.small", "ubuntu"),
+			defaultEnvVariables("u1.small", "ubuntu"),
 		),
 		UseForDocs: false,
 	},
@@ -109,10 +109,10 @@ func gatherArtifacts(registry *[]Entry, gatherers []api.ArtifactsGatherer) {
 	}
 }
 
-func defaultLabels(defaultInstancetype, defaultPreference string) map[string]string {
+func defaultEnvVariables(defaultInstancetype, defaultPreference string) map[string]string {
 	return map[string]string{
-		instancetype.DefaultInstancetypeLabel: defaultInstancetype,
-		instancetype.DefaultPreferenceLabel:   defaultPreference,
+		common.DefaultInstancetypeEnv: defaultInstancetype,
+		common.DefaultPreferenceEnv:   defaultPreference,
 	}
 }
 

--- a/cmd/medius/images/push.go
+++ b/cmd/medius/images/push.go
@@ -134,7 +134,7 @@ func (b *buildAndPublish) Do(entry *common.Entry, timestamp time.Time) ([]string
 	defer os.Remove(file)
 
 	b.Log.Info("Building containerdisk ...")
-	containerDisk, err := build.ContainerDisk(file, build.ContainerDiskConfig(artifactInfo.SHA256Sum, metadata.AdditionalLabels))
+	containerDisk, err := build.ContainerDisk(file, build.ContainerDiskConfig(artifactInfo.SHA256Sum, metadata.EnvVariables))
 	if err != nil {
 		return nil, fmt.Errorf("error creating the containerdisk : %v", err)
 	}

--- a/pkg/api/artifact.go
+++ b/pkg/api/artifact.go
@@ -50,9 +50,9 @@ type Metadata struct {
 	Description string
 	// CloudInit/Ignition Payload example.
 	ExampleUserData docs.UserData
-	// AdditionalLabels contains additional labels which should be added to the resulting containerdisk.
-	// These labels can e.g. describe an appropriate instancetype or preference.
-	AdditionalLabels map[string]string
+	// EnvVariables contains additional env variables which should be added to the resulting containerdisk.
+	// These env variables can e.g. describe an appropriate instancetype or preference.
+	EnvVariables map[string]string
 }
 
 func (m Metadata) Describe() string {

--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -2,7 +2,6 @@ package build
 
 import (
 	"fmt"
-	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
@@ -15,20 +14,14 @@ const (
 	ImageArchitecture = "amd64"
 )
 
-func ContainerDiskConfig(checksum string, additionalLabels map[string]string) v1.Config {
+func ContainerDiskConfig(checksum string, envVariables map[string]string) v1.Config {
 	labels := map[string]string{
 		LabelShaSum: checksum,
 	}
-	for k, v := range additionalLabels {
-		labels[k] = v
-	}
 
-	// Add all labels also as ENV variable for compatibility with crun-vm
-	// Replace illegal characters with underscore
 	var env []string
-	r := strings.NewReplacer(".", "_", "/", "_", "-", "_")
-	for k, v := range labels {
-		env = append(env, fmt.Sprintf("%s=%s", strings.ToUpper(r.Replace(k)), v))
+	for k, v := range envVariables {
+		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
 	return v1.Config{Labels: labels, Env: env}

--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,0 +1,6 @@
+package common
+
+const (
+	DefaultInstancetypeEnv = "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_INSTANCETYPE"
+	DefaultPreferenceEnv   = "INSTANCETYPE_KUBEVIRT_IO_DEFAULT_PREFERENCE"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Since ENV variables were chosen as the way forward to decorate containerdisks with appropriate default instancetypes and preferences the labels are dropped from the built containerdisks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Labels are dropped from containerdisks, only env variables are kept to decorate images.
```
