### PR TITLE
registry: Bump default instance type env variables

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -31,37 +31,37 @@ var staticRegistry = []Entry{
 	},
 	{
 		Artifacts: []api.Artifact{
-			centos.New("7-2009", defaultEnvVariables("u1.small", "centos.7")),
+			centos.New("7-2009", defaultEnvVariables("u1.medium", "centos.7")),
 		},
 		UseForDocs: true,
 	},
 	{
 		Artifacts: []api.Artifact{
-			centosstream.New("9", &docs.UserData{Username: "cloud-user"}, defaultEnvVariables("u1.small", "centos.stream9")),
+			centosstream.New("9", &docs.UserData{Username: "cloud-user"}, defaultEnvVariables("u1.medium", "centos.stream9")),
 		},
 		UseForDocs: true,
 	},
 	{
 		Artifacts: []api.Artifact{
-			centosstream.New("8", &docs.UserData{Username: "centos"}, defaultEnvVariables("u1.small", "centos.stream8")),
+			centosstream.New("8", &docs.UserData{Username: "centos"}, defaultEnvVariables("u1.medium", "centos.stream8")),
 		},
 		UseForDocs: false,
 	},
 	{
 		Artifacts: []api.Artifact{
-			ubuntu.New("22.04", defaultEnvVariables("u1.small", "ubuntu")),
+			ubuntu.New("22.04", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
 		UseForDocs: true,
 	},
 	{
 		Artifacts: []api.Artifact{
-			ubuntu.New("20.04", defaultEnvVariables("u1.small", "ubuntu")),
+			ubuntu.New("20.04", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
 		UseForDocs: false,
 	},
 	{
 		Artifacts: []api.Artifact{
-			ubuntu.New("18.04", defaultEnvVariables("u1.small", "ubuntu")),
+			ubuntu.New("18.04", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
 		UseForDocs: false,
 	},


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

This brings them in-line with the DataImportCrons provided by HCO to SSP that all use the u1.medium default instance type:

```yaml
$ yq .[].metadata hyperconverged-cluster-operator/assets/dataImportCronTemplates/dataImportCronTemplates.yaml annotations:
  cdi.kubevirt.io/storage.bind.immediate.requested: "true"
name: centos-stream8-image-cron
labels:
  instancetype.kubevirt.io/default-preference: centos.stream8
  instancetype.kubevirt.io/default-instancetype: u1.medium
annotations:
  cdi.kubevirt.io/storage.bind.immediate.requested: "true"
name: centos-stream9-image-cron
labels:
  instancetype.kubevirt.io/default-preference: centos.stream9
  instancetype.kubevirt.io/default-instancetype: u1.medium
annotations:
  cdi.kubevirt.io/storage.bind.immediate.requested: "true"
name: fedora-image-cron
labels:
  instancetype.kubevirt.io/default-preference: fedora
  instancetype.kubevirt.io/default-instancetype: u1.medium
annotations:
  cdi.kubevirt.io/storage.bind.immediate.requested: "true"
name: centos-7-image-cron
labels:
  instancetype.kubevirt.io/default-preference: centos.7
  instancetype.kubevirt.io/default-instancetype: u1.medium
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
