### PR TITLE
Set containerdisks' entrypoint to "no-entrypoint"

### DIFF
--- a/pkg/build/build.go
+++ b/pkg/build/build.go
@@ -26,7 +26,19 @@ func ContainerDiskConfig(checksum string, envVariables map[string]string) v1.Con
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	return v1.Config{Labels: labels, Env: env}
+	// OCI runtimes like crun-vm [1] may be able to run a containerdisk container image directly, in which case it
+	// would be unfortunate to require the user to pass in a placeholder entrypoint to docker-run and equivalents,
+	// since engines like Docker require an entrypoint to be set, e.g.:
+	//
+	//   $ docker run --runtime crun-vm quay.io/containerdisks/fedora:39 unused-entrypoint
+	//
+	// Instead we set the entrypoint to a predetermined "no-entrypoint" value that runtimes like crun-vm can
+	// interpret as there not being an entrypoint.
+	//
+	// [1] https://github.com/containers/crun-vm
+	entrypoint := []string{"no-entrypoint"}
+
+	return v1.Config{Labels: labels, Env: env, Entrypoint: entrypoint}
 }
 
 func ContainerDisk(imgPath, imgArch string, config v1.Config) (v1.Image, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

OCI runtimes like [crun-vm](https://github.com/containers/crun-vm) may be able to run a containerdisk container image directly, in which case it is unfortunate that user must pass in a placeholder entrypoint to docker-run and equivalents, since engines like Docker require an entrypoint to be set:

```console
$ docker run --runtime crun-vm quay.io/containerdisks/fedora:39 unused-entrypoint
```

Instead, set the entrypoint to a predetermined "no-entrypoint" value that runtimes like crun-vm can interpret as there not being an entrypoint.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Changed: The entrypoint for all containerdisks is now ["no-entrypoint"]
```
