### PR TITLE
fix(fedora): Add subvariant filter to Fedora gatherer

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -38,10 +38,11 @@ type fedora struct {
 }
 
 type fedoraGatherer struct {
-	Version string
-	Archs   []string
-	Variant string
-	getter  http.Getter
+	Version    string
+	Archs      []string
+	Variant    string
+	Subvariant string
+	getter     http.Getter
 }
 
 const minimumVersion = 38
@@ -177,6 +178,7 @@ func (f *fedoraGatherer) releaseMatches(release *Release) bool {
 		if release.Arch == arch {
 			return version >= minimumVersion &&
 				release.Variant == f.Variant &&
+				release.Subvariant == f.Subvariant &&
 				strings.HasSuffix(release.Link, "qcow2")
 		}
 	}
@@ -211,8 +213,9 @@ func New(release, arch string) *fedora {
 
 func NewGatherer() *fedoraGatherer {
 	return &fedoraGatherer{
-		Archs:   []string{"x86_64", "aarch64"},
-		Variant: "Cloud",
-		getter:  &http.HTTPGetter{},
+		Archs:      []string{"x86_64", "aarch64"},
+		Variant:    "Cloud",
+		Subvariant: "Cloud_Base",
+		getter:     &http.HTTPGetter{},
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Because Fedora is now publishing Cloud_Base and Cloud_Base_UKI subvariants under the Cloud variant of Fedora, a filter for the Cloud_Base subvariant is added. This avoids creating Fedora containerdisks with more than a single image per architecture.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
