### PR TITLE
fix(fedora): Fix Fedora version parsing and add filter for subvariants

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -3,6 +3,7 @@ package fedora
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -53,6 +54,8 @@ const description = `<img src="https://upload.wikimedia.org/wikipedia/commons/th
 <br />
 Visit [getfedora.org](https://getfedora.org/) to learn more about the Fedora project.`
 
+var additionalUniqueTagRegExp = regexp.MustCompile(`\d+-\d+\.\d+`)
+
 func (f *fedora) Metadata() *api.Metadata {
 	return &api.Metadata{
 		Name:        "fedora",
@@ -76,17 +79,19 @@ func (f *fedora) Inspect() (*api.ArtifactDetails, error) {
 			continue
 		}
 
+		details := &api.ArtifactDetails{
+			SHA256Sum:         release.Sha256,
+			DownloadURL:       release.Link,
+			ImageArchitecture: architecture.GetImageArchitecture(f.Arch),
+		}
+
 		components := strings.Split(release.Link, "/")
 		fileName := components[len(components)-1]
-		suffix := fmt.Sprintf(".%s.qcow2", f.Arch)
-		additionalTag := strings.TrimSuffix(strings.TrimPrefix(fileName, "Fedora-Cloud-Base-"), suffix)
+		if matches := additionalUniqueTagRegExp.FindStringSubmatch(fileName); len(matches) > 0 {
+			details.AdditionalUniqueTags = append(details.AdditionalUniqueTags, matches[0])
+		}
 
-		return &api.ArtifactDetails{
-			SHA256Sum:            release.Sha256,
-			DownloadURL:          release.Link,
-			AdditionalUniqueTags: []string{additionalTag},
-			ImageArchitecture:    architecture.GetImageArchitecture(f.Arch),
-		}, nil
+		return details, nil
 	}
 
 	return nil, fmt.Errorf("no release information in releases.json for fedora:%q found", f.Version)

--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -38,10 +38,11 @@ type fedora struct {
 }
 
 type fedoraGatherer struct {
-	Version string
-	Archs   []string
-	Variant string
-	getter  http.Getter
+	Version    string
+	Archs      []string
+	Variant    string
+	Subvariant string
+	getter     http.Getter
 }
 
 const minimumVersion = 38
@@ -177,6 +178,7 @@ func (f *fedoraGatherer) releaseMatches(release *Release) bool {
 		if release.Arch == arch {
 			return version >= minimumVersion &&
 				release.Variant == f.Variant &&
+				release.Subvariant == f.Subvariant &&
 				strings.HasSuffix(release.Link, "qcow2")
 		}
 	}
@@ -211,8 +213,9 @@ func New(release, arch string) *fedora {
 
 func NewGatherer() *fedoraGatherer {
 	return &fedoraGatherer{
-		Archs:   []string{"x86_64", "aarch64"},
-		Variant: "Cloud",
-		getter:  &http.HTTPGetter{},
+		Archs:      []string{"x86_64", "aarch64"},
+		Variant:    "Cloud",
+		Subvariant: "Cloud_Base",
+		getter:     &http.HTTPGetter{},
 	}
 }

--- a/artifacts/fedora/fedora_test.go
+++ b/artifacts/fedora/fedora_test.go
@@ -23,6 +23,42 @@ var _ = Describe("Fedora", func() {
 			Expect(got).To(Equal(details))
 			Expect(c.Metadata()).To(Equal(metadata))
 		},
+		Entry("fedora:40 x86_64", "40", "x86_64", "testdata/releases.json",
+			&api.ArtifactDetails{
+				SHA256Sum:            "ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee",
+				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2", //nolint:lll
+				AdditionalUniqueTags: []string{"40-1.14"},
+				ImageArchitecture:    "amd64",
+			},
+			&api.Metadata{
+				Name:        "fedora",
+				Version:     "40",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "fedora",
+				},
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: defaultInstancetypeX86_64,
+					common.DefaultPreferenceEnv:   defaultPreferenceX86_64,
+				},
+			},
+		),
+		Entry("fedora:40 aarch64", "40", "aarch64", "testdata/releases.json",
+			&api.ArtifactDetails{
+				SHA256Sum:            "ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459",
+				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.14.qcow2", //nolint:lll
+				AdditionalUniqueTags: []string{"40-1.14"},
+				ImageArchitecture:    "arm64",
+			},
+			&api.Metadata{
+				Name:        "fedora",
+				Version:     "40",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "fedora",
+				},
+			},
+		),
 		Entry("fedora:39 x86_64", "39", "x86_64", "testdata/releases.json",
 			&api.ArtifactDetails{
 				SHA256Sum:            "ab5be5058c5c839528a7d6373934e0ce5ad6c8f80bd71ed3390032027da52f37",
@@ -59,49 +95,13 @@ var _ = Describe("Fedora", func() {
 				},
 			},
 		),
-		Entry("fedora:38 x86_64", "38", "x86_64", "testdata/releases.json",
-			&api.ArtifactDetails{
-				SHA256Sum:            "d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482",
-				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2", //nolint:lll
-				AdditionalUniqueTags: []string{"38-1.6"},
-				ImageArchitecture:    "amd64",
-			},
-			&api.Metadata{
-				Name:        "fedora",
-				Version:     "38",
-				Description: description,
-				ExampleUserData: docs.UserData{
-					Username: "fedora",
-				},
-				EnvVariables: map[string]string{
-					common.DefaultInstancetypeEnv: defaultInstancetypeX86_64,
-					common.DefaultPreferenceEnv:   defaultPreferenceX86_64,
-				},
-			},
-		),
-		Entry("fedora:38 aarch64", "38", "aarch64", "testdata/releases.json",
-			&api.ArtifactDetails{
-				SHA256Sum:            "ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65",
-				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2", //nolint:lll
-				AdditionalUniqueTags: []string{"38-1.6"},
-				ImageArchitecture:    "arm64",
-			},
-			&api.Metadata{
-				Name:        "fedora",
-				Version:     "38",
-				Description: description,
-				ExampleUserData: docs.UserData{
-					Username: "fedora",
-				},
-			},
-		),
 	)
 
 	It("Gather should be able to parse releases files", func() {
 		artifacts := [][]api.Artifact{
 			{
 				&fedora{
-					Version: "39",
+					Version: "40",
 					Arch:    "x86_64",
 					Variant: "Cloud",
 					getter:  &http.HTTPGetter{},
@@ -111,7 +111,7 @@ var _ = Describe("Fedora", func() {
 					},
 				},
 				&fedora{
-					Version: "39",
+					Version: "40",
 					Arch:    "aarch64",
 					Variant: "Cloud",
 					getter:  &http.HTTPGetter{},
@@ -119,7 +119,7 @@ var _ = Describe("Fedora", func() {
 			},
 			{
 				&fedora{
-					Version: "38",
+					Version: "39",
 					Arch:    "x86_64",
 					Variant: "Cloud",
 					getter:  &http.HTTPGetter{},
@@ -129,7 +129,7 @@ var _ = Describe("Fedora", func() {
 					},
 				},
 				&fedora{
-					Version: "38",
+					Version: "39",
 					Arch:    "aarch64",
 					Variant: "Cloud",
 					getter:  &http.HTTPGetter{},

--- a/artifacts/fedora/testdata/releases.json
+++ b/artifacts/fedora/testdata/releases.json
@@ -1,538 +1,610 @@
 [
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/x86_64/images/Fedora-Cloud-Base-AmazonEC2.x86_64-40-1.10.raw.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-GCE.x86_64-40-1.14.tar.gz",
     "variant": "Cloud",
     "subvariant": "Cloud_Base",
-    "sha256": "66dc695ce7c7949516d915576b729f484445fc832d2bc5ff505575e04fd251ee",
-    "size": "368549988"
+    "sha256": "dcc05425e07b87f6f53f142c693bff3d47942fa4b05e1e08ab122db57ba478b5",
+    "size": "400065273"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/x86_64/images/Fedora-Cloud-Base-GCE.x86_64-40-1.10.tar.gz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-AmazonEC2.x86_64-40-1.14.raw.xz",
     "variant": "Cloud",
     "subvariant": "Cloud_Base",
-    "sha256": "7284937103b1d6fa09374b2a31db4d17c1c4f5d3a467c9a9d2283d3c782514d7",
-    "size": "401823271"
+    "sha256": "42c682c2c77ead24ea6af989d1fed28d93e2134c85b016674e109ee6f6699446",
+    "size": "366518332"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.10.qcow2",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2",
     "variant": "Cloud",
     "subvariant": "Cloud_Base",
-    "sha256": "8c2d3f4d2379d45f4da99d33e0ded893f136baeb21647f1d50a99ba03acbc1f1",
-    "size": "399507456"
+    "sha256": "ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee",
+    "size": "397475840"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/x86_64/images/Fedora-Cloud-Base-UEFI-UKI.x86_64-40-1.10.qcow2",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-UEFI-UKI.x86_64-40-1.14.qcow2",
     "variant": "Cloud",
     "subvariant": "Cloud_Base_UKI",
-    "sha256": "73628ef46ceaab0b26ed172078ba59b32138f230e4fc68c691eb3812aecdde86",
-    "size": "402718720"
+    "sha256": "e58fbd6c147c0eda6eca72491ddc74871c3c3db9b808dc4fcf0d313510c43d81",
+    "size": "403767296"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/aarch64/images/Fedora-Cloud-Base-AmazonEC2.aarch64-40-1.10.raw.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-GCE.aarch64-40-1.14.tar.gz",
     "variant": "Cloud",
     "subvariant": "Cloud_Base",
-    "sha256": "38975e67aad363d55f6d37e70e5cb27de6ce988c8b57cd6064a549cbc04c65e6",
-    "size": "365349116"
+    "sha256": "7153713f2a44607376b45786f609026cd64b2c3e276ee421c70a6f4fea74b501",
+    "size": "407577788"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/aarch64/images/Fedora-Cloud-Base-GCE.aarch64-40-1.10.tar.gz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-AmazonEC2.aarch64-40-1.14.raw.xz",
     "variant": "Cloud",
     "subvariant": "Cloud_Base",
-    "sha256": "f0b016267637442e1bd0dcc7bd6dc36276a178b012df3a1d3c60457671d553dd",
-    "size": "403681921"
+    "sha256": "ab0fcaf5b5bbb4362d3757ff5e3fcea04fb4a4d6c501c19c1a55064194290230",
+    "size": "365970064"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.10.qcow2",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.14.qcow2",
     "variant": "Cloud",
     "subvariant": "Cloud_Base",
-    "sha256": "d760b2c4d9281f2de6e93ef14fa2b1bbbaa0e2294eb7b3131b9e445ecf6b3e8d",
-    "size": "404619264"
+    "sha256": "ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459",
+    "size": "408289280"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Cloud/aarch64/images/Fedora-Cloud-Base-UEFI-UKI.aarch64-40-1.10.qcow2",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-UEFI-UKI.aarch64-40-1.14.qcow2",
     "variant": "Cloud",
     "subvariant": "Cloud_Base_UKI",
-    "sha256": "30585c6c43edc6cf0ae5ad257530c887b1d727ac909dd33af35f5d4b31a4494b",
-    "size": "395771904"
+    "sha256": "95224953d04b8af9447c5422e6af819e8e47a961476528b9b814dc52d48f424e",
+    "size": "400883712"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Container/x86_64/images/Fedora-Container-Base-Generic-Minimal.x86_64-40-1.10.oci.tar.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Container/x86_64/images/Fedora-Container-Base-Generic-Minimal.x86_64-40-1.14.oci.tar.xz",
     "variant": "Container",
     "subvariant": "Container_Minimal_Base",
-    "sha256": "8d702e70164dd18266d7b6fba2f8e9e471337b1bca4faabd8e7065299120f93c",
-    "size": "46097388"
+    "sha256": "78434b6f41b209a2ed882b0c0f4f9f78a20aa965899c7860da24d02ab11235e3",
+    "size": "45908620"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Container/x86_64/images/Fedora-Container-Base-Generic.x86_64-40-1.10.oci.tar.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Container/x86_64/images/Fedora-Container-Base-Generic.x86_64-40-1.14.oci.tar.xz",
     "variant": "Container",
     "subvariant": "Container_Base",
-    "sha256": "70c9423c27c95dddf5770dd0a5268cdf580c760706e808aa0b313d6748b0c83a",
-    "size": "80765776"
+    "sha256": "c5c9dc3320ca474ff40b5a378b443a2b290f258a08e909a43fe81ca7a9bbe966",
+    "size": "81711536"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Container/x86_64/images/Fedora-Container-Toolbox.x86_64-40-1.10.oci.tar.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Container/x86_64/images/Fedora-Container-Toolbox.x86_64-40-1.14.oci.tar.xz",
     "variant": "Container",
     "subvariant": "Container_Toolbox",
-    "sha256": "6e3366edc9aa05a539d3dd9c1d13efd62c3e56c22b6d3cc9b14af3dfbf0ffea0",
-    "size": "333632240"
+    "sha256": "335900c5185c273e68da30c461ba4739f0a9692a8013014032c9929396840bf8",
+    "size": "323370324"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Container/aarch64/images/Fedora-Container-Base-Generic-Minimal.aarch64-40-1.10.oci.tar.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Container/aarch64/images/Fedora-Container-Base-Generic-Minimal.aarch64-40-1.14.oci.tar.xz",
     "variant": "Container",
     "subvariant": "Container_Minimal_Base",
-    "sha256": "c6c9dc8ce2f5760ae09a5ba719f115a3a02f023d8fe3d658a20a26a2ad2370ea",
-    "size": "44535944"
+    "sha256": "e374388c2a158729dcc7e9b4d61507ee0146103119eb711e9b91745e559ee94b",
+    "size": "44594488"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Container/aarch64/images/Fedora-Container-Base-Generic.aarch64-40-1.10.oci.tar.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Container/aarch64/images/Fedora-Container-Base-Generic.aarch64-40-1.14.oci.tar.xz",
     "variant": "Container",
     "subvariant": "Container_Base",
-    "sha256": "426d7c54c1d35b6659594ec2e7a4c8bb3f9aeae8e7bd8ffe25b1a834fd720d55",
-    "size": "79071232"
+    "sha256": "8f7262dfaf502787581c49669d73b3bd0210b5d916f1d669b9a5737ad1a84830",
+    "size": "80074648"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Container/aarch64/images/Fedora-Container-Toolbox.aarch64-40-1.10.oci.tar.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Container/aarch64/images/Fedora-Container-Toolbox.aarch64-40-1.14.oci.tar.xz",
     "variant": "Container",
     "subvariant": "Container_Toolbox",
-    "sha256": "bc97026807ade4a058e8dde6231e64c53f9cb3f672c88cc571075674180266cf",
-    "size": "306894436"
+    "sha256": "247ec625257f0da9f5ce637e65900e61a127e60f508c8f489c13a14521a6f8a4",
+    "size": "302343672"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-40-1.14.iso",
     "variant": "Everything",
     "subvariant": "Everything",
-    "sha256": "608d96ec117adac51383c60c6a0d0d887349f092e6153e4077c531fbe96c1dfe",
-    "size": "807098368"
+    "sha256": "4d1c0a7dda6c1d21a1483acb6c7914193158921113f947c5a0519d26bcc548b2",
+    "size": "812255232"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Everything/aarch64/iso/Fedora-Everything-netinst-aarch64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Everything/aarch64/iso/Fedora-Everything-netinst-aarch64-40-1.14.iso",
     "variant": "Everything",
     "subvariant": "Everything",
-    "sha256": "fcfff7e78b8abbf31dc016a91a4f8f5c416cbd58567da61e12de23ff33a0f5e1",
-    "size": "832819200"
+    "sha256": "512d1da43a71cde6fd20a4c2f5cae39fab2966fe6d3ad491964dd0be9b0772fc",
+    "size": "837763072"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Kinoite/x86_64/images/Fedora-Kinoite-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Kinoite/x86_64/images/Fedora-Kinoite-40.1.14.ociarchive",
     "variant": "Kinoite",
     "subvariant": "Kinoite"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Kinoite/x86_64/iso/Fedora-Kinoite-ostree-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Kinoite/x86_64/iso/Fedora-Kinoite-ostree-x86_64-40-1.14.iso",
     "variant": "Kinoite",
     "subvariant": "Kinoite",
-    "sha256": "2b502043fc56b13ce1e52c306f55cf124fb514b22f1fc67044a1853a7ed349df",
-    "size": "4165603328"
+    "sha256": "c6abc4d88de97fd62f42b299cd2879a0e68d9552c9cfd3cc98753a1ff27be16c",
+    "size": "4181080064"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Kinoite/aarch64/images/Fedora-Kinoite-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Kinoite/aarch64/images/Fedora-Kinoite-40.1.14.ociarchive",
     "variant": "Kinoite",
     "subvariant": "Kinoite"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Kinoite/aarch64/iso/Fedora-Kinoite-ostree-aarch64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Kinoite/aarch64/iso/Fedora-Kinoite-ostree-aarch64-40-1.14.iso",
     "variant": "Kinoite",
     "subvariant": "Kinoite",
-    "sha256": "349e1cbdf2bb7ba28ef10ec7b6f204e5fe9ff5388e27cde68d324bbe354495e4",
-    "size": "4139296768"
+    "sha256": "6fb0687148f494ba273eb9e278bcf269f88be7d1783c6e380067d540a995fbda",
+    "size": "4161081344"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Sericea/x86_64/images/Fedora-Sericea-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Sericea/x86_64/images/Fedora-Sericea-40.1.14.ociarchive",
     "variant": "Sericea",
     "subvariant": "Sericea"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Sericea/x86_64/iso/Fedora-Sericea-ostree-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Sericea/x86_64/iso/Fedora-Sericea-ostree-x86_64-40-1.14.iso",
     "variant": "Sericea",
     "subvariant": "Sericea",
-    "sha256": "e48a57dd45cf2b8b46eafe604882559dc075eccf1532ec76fbbdefc3c6fc16db",
-    "size": "2504404992"
+    "sha256": "9b8cce1ecbaba24a7e8db1b401b240382954acee5fb9993ad4b536f42f9186a6",
+    "size": "2536486912"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Sericea/aarch64/images/Fedora-Sericea-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Sericea/aarch64/images/Fedora-Sericea-40.1.14.ociarchive",
     "variant": "Sericea",
     "subvariant": "Sericea"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/x86_64/images/Fedora-Server-KVM-40_Beta-1.10.x86_64.qcow2",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/x86_64/images/Fedora-Server-KVM-40-1.14.x86_64.qcow2",
     "variant": "Server",
     "subvariant": "Server_KVM",
-    "sha256": "4027ff2472251c863baca6c6a96b5ed2d63e062b86dd1ad80e6fa6596850d054",
-    "size": "658243584"
+    "sha256": "a16ba1f26aaf010f62bd94e9f772079353e4bbcffe2c8078f1dfab8aeb848851",
+    "size": "658702336"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/x86_64/iso/Fedora-Server-dvd-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/x86_64/iso/Fedora-Server-dvd-x86_64-40-1.14.iso",
     "variant": "Server",
     "subvariant": "Server",
-    "sha256": "89ed544a677aa73ab81871b428da2ecad461edfe2ea44818416308eacb1c2712",
-    "size": "2626813952"
+    "sha256": "32d9ab1798fc8106a0b06e873bdcd83a3efea8412c9401dfe4097347ed0cfc65",
+    "size": "2612854784"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/x86_64/iso/Fedora-Server-netinst-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/x86_64/iso/Fedora-Server-netinst-x86_64-40-1.14.iso",
     "variant": "Server",
     "subvariant": "Server",
-    "sha256": "f83f99d12991025bbf530101feca82bbc103e0b59f50910b9a79eb279db75caf",
-    "size": "807157760"
+    "sha256": "1b4f163c55aa9b35bb08f3d465534aa68899a4984b8ba8976b1e7b28297b61fe",
+    "size": "812312576"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/aarch64/images/Fedora-Server-40_Beta-1.10.aarch64.raw.xz",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/aarch64/images/Fedora-Server-40-1.14.aarch64.raw.xz",
     "variant": "Server",
     "subvariant": "Server",
-    "sha256": "f19d49cc45e0534362cb09751159a8b9d584a5e36aaaab9ee6757f0823eb49b9",
-    "size": "1104465732"
+    "sha256": "a624d7275bf8538ee875a5f69b60b04d9114ad6ea918ecad160dde24b4b75b35",
+    "size": "1108904380"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/aarch64/images/Fedora-Server-KVM-40_Beta-1.10.aarch64.qcow2",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/aarch64/images/Fedora-Server-KVM-40-1.14.aarch64.qcow2",
     "variant": "Server",
     "subvariant": "Server_KVM",
-    "sha256": "88b670ddc42b7794b52ee8d166dbbe441f73cb4c10f47337e818de6844dca830",
-    "size": "675414016"
+    "sha256": "2fed4e38a927824704d6bd88466b3b938543b335669e470981fa123f965f1c68",
+    "size": "672661504"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/aarch64/iso/Fedora-Server-dvd-aarch64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/aarch64/iso/Fedora-Server-dvd-aarch64-40-1.14.iso",
     "variant": "Server",
     "subvariant": "Server",
-    "sha256": "329c0514b9fba28b7b00714cc9311397bf9be8d6ab4bf4b398c05a9326dc3f63",
-    "size": "2553872384"
+    "sha256": "9146b9563d68c9c9cc53fac75f5e9caefaff8d0e350cd6c4312553deb99b5430",
+    "size": "2535260160"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Server/aarch64/iso/Fedora-Server-netinst-aarch64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Server/aarch64/iso/Fedora-Server-netinst-aarch64-40-1.14.iso",
     "variant": "Server",
     "subvariant": "Server",
-    "sha256": "6b91426603263a7551140fd3c83387d75707459a3ab3396a226b5f078867fbbf",
-    "size": "832888832"
+    "sha256": "690731ac6abba81413d97517baa80841cb122d07b296ec3f2935848be45be8fe",
+    "size": "837820416"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Silverblue/x86_64/images/Fedora-Silverblue-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Silverblue/x86_64/images/Fedora-Silverblue-40.1.14.ociarchive",
     "variant": "Silverblue",
     "subvariant": "Silverblue"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-40-1.14.iso",
     "variant": "Silverblue",
     "subvariant": "Silverblue",
-    "sha256": "2ae231b4b7425c9ef49a7e4c601a6102b539fbb4cfe5c942a2df4d383c2c7066",
-    "size": "3589492736"
+    "sha256": "8f49c9880cf0eb24e0461498d27d3d5134f056975c478f7d0febb1b9e5d1edbb",
+    "size": "3582482432"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Silverblue/aarch64/images/Fedora-Silverblue-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Silverblue/aarch64/images/Fedora-Silverblue-40.1.14.ociarchive",
     "variant": "Silverblue",
     "subvariant": "Silverblue"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Silverblue/aarch64/iso/Fedora-Silverblue-ostree-aarch64-40-1.14.iso",
     "variant": "Silverblue",
     "subvariant": "Silverblue",
-    "sha256": "d9cf263fdf86e3786d8af0d4894f7782ea9db44bbc4630f2ff88abd9ffca47e8",
-    "size": "3573426176"
+    "sha256": "c482885894c0ff722c305ca36259dc59d94a36582053b64d6042287c103c9c1c",
+    "size": "3573305344"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-Budgie-Live-x86_64-40_Beta-1.10.iso",
-    "variant": "Spins",
-    "subvariant": "Budgie",
-    "sha256": "d11d409a03d66eaaabf4c5e3480aff0fe77065cad81d652286879c1144b2bfab",
-    "size": "2124746752"
-  },
-  {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-Cinnamon-Live-x86_64-40_Beta-1.10.iso",
-    "variant": "Spins",
-    "subvariant": "Cinnamon",
-    "sha256": "f924ac4223a07a42162f6648dbfcfc91810dfaba4c4e91771363f38cec09d332",
-    "size": "2526021632"
-  },
-  {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-40_Beta-1.10.iso",
-    "variant": "Spins",
-    "subvariant": "KDE",
-    "sha256": "7f6018f113969ca531e7654a55103470f6745cf3468a3f7f8478e255e331c02e",
-    "size": "2637453312"
-  },
-  {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-LXDE-Live-x86_64-40_Beta-1.10.iso",
-    "variant": "Spins",
-    "subvariant": "LXDE",
-    "sha256": "5bd08568fe1b86c2eaaecc0344e31ee80ca78a4ccaa20742def724471db5993b",
-    "size": "1716133888"
-  },
-  {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-LXQt-Live-x86_64-40_Beta-1.10.iso",
-    "variant": "Spins",
-    "subvariant": "LXQt",
-    "sha256": "b8055384f3d112a022d483c6e3f64191da2d081555dc3922583eb3e168f8c8ba",
-    "size": "1963407360"
-  },
-  {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-MATE_Compiz-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-MATE_Compiz-Live-x86_64-40-1.14.iso",
     "variant": "Spins",
     "subvariant": "Mate",
-    "sha256": "c2b7a3cc34ae370fdf8f0ccd06ff9521af7872b73938d3dce1da12240983c87b",
-    "size": "2446178304"
+    "sha256": "3242eb53dd2d0bad66dff04f7e54848aa750910171a110e2f8677aa23b8e84e0",
+    "size": "2454198272"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-SoaS-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-Budgie-Live-x86_64-40-1.14.iso",
+    "variant": "Spins",
+    "subvariant": "Budgie",
+    "sha256": "18a2876d031fd58d00d9a37d3a823caa03cf7059309bed1de79eb3a46dc4bc21",
+    "size": "2146633728"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-Cinnamon-Live-x86_64-40-1.14.iso",
+    "variant": "Spins",
+    "subvariant": "Cinnamon",
+    "sha256": "081ac2402d3e2e704d36ee6aacd67ba631d1939e0c35cf517e996dbb70117735",
+    "size": "2558238720"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-40-1.14.iso",
+    "variant": "Spins",
+    "subvariant": "KDE",
+    "sha256": "8b9da20cfa947b16c8f0c5187e9b4389e13821e31b062688a48cf1b3028c335c",
+    "size": "2645645312"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-LXDE-Live-x86_64-40-1.14.iso",
+    "variant": "Spins",
+    "subvariant": "LXDE",
+    "sha256": "3be326068be6bd7e98d7e7e89f4427648fe83484ecd36e1e77304af1369d1920",
+    "size": "1741191168"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-LXQt-Live-x86_64-40-1.14.iso",
+    "variant": "Spins",
+    "subvariant": "LXQt",
+    "sha256": "ef0fbed423acc7484b6fea14a062c41a3026ca93d71edf28debe2d883f9ce61c",
+    "size": "1845794816"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-SoaS-Live-x86_64-40-1.14.iso",
     "variant": "Spins",
     "subvariant": "SoaS",
-    "sha256": "ef17f56f616c2a5d5b7a746f72586249778f2451463381466d34cf41fdb1bdd8",
-    "size": "1435232256"
+    "sha256": "4287b380b4be2f2c421178b9dfdcaf8c64ed58e343baa7d1d482c4f3481975fb",
+    "size": "1440874496"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-Sway-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-Sway-Live-x86_64-40-1.14.iso",
     "variant": "Spins",
     "subvariant": "Sway",
-    "sha256": "862bfb3af975e5c2242892cef810a61e1c679c52fe109cba4ba844297a307e45",
-    "size": "1629048832"
+    "sha256": "6974428b65153156e133fe0165cdf5cb4420b987fe27c53218480414b685e602",
+    "size": "1637679104"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-Xfce-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-Xfce-Live-x86_64-40-1.14.iso",
     "variant": "Spins",
     "subvariant": "Xfce",
-    "sha256": "afa00fa255feb141bf584768d47db36f0c0afb34100196633f8fada7b2ee1c00",
-    "size": "1863948288"
+    "sha256": "519db49a21587c007b8135cfc8fba470951937d2f7edc01a8f4b96abc772370c",
+    "size": "1889988608"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Spins/x86_64/iso/Fedora-i3-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/x86_64/iso/Fedora-i3-Live-x86_64-40-1.14.iso",
     "variant": "Spins",
     "subvariant": "i3",
-    "sha256": "a33d9f1c9917be2a08c0d7321bc237b99ec7d826ac86f95652cbaf02cbd9d3a6",
-    "size": "1610858496"
+    "sha256": "1f55028b79c6633178a0106fdb3d34ccb489f1dc039c5e96a829cea28624d7a8",
+    "size": "1617053696"
   },
   {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Workstation/x86_64/iso/Fedora-Workstation-Live-osb-40_Beta-1.10.x86_64.iso",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "59fabc22b89c80967da23c922ac76be0a96e0f74b4877705aad24f3cb733d45d",
-    "size": "2614689792"
-  },
-  {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-40_Beta-1.10.iso",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "ede3d2a07744fbebcb32e84baecd327aed06d7ba158fd4423d8ce143200bae69",
-    "size": "2284748800"
-  },
-  {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Workstation/aarch64/images/Fedora-Workstation-40_Beta-1.10.aarch64.raw.xz",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "1ee78de96bc5900dd651d3d2c33677e4390d64967e2a1104332fd037a9380665",
-    "size": "2619408200"
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/aarch64/images/Fedora-KDE-40-1.14.aarch64.raw.xz",
+    "variant": "Spins",
+    "subvariant": "KDE",
+    "sha256": "3840ebba322b9a24867a777c472f510a47193db90cf96a51da074758cc5299e1",
+    "size": "3297951536"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Workstation/aarch64/iso/Fedora-Workstation-Live-osb-40_Beta-1.10.aarch64.iso",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "9637aab9e1f8eb5738274274dd6bc22f36b6cb7a7aa72b518674556e4e6c0a19",
-    "size": "2575841280"
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/aarch64/images/Fedora-LXQt-40-1.14.aarch64.raw.xz",
+    "variant": "Spins",
+    "subvariant": "LXQt",
+    "sha256": "9a0aa0a82a10edc184f67c1c2609f11f06a2ea43dd6801863df4189dd647e62b",
+    "size": "1995815572"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/aarch64/images/Fedora-Minimal-40-1.14.aarch64.raw.xz",
+    "variant": "Spins",
+    "subvariant": "Minimal",
+    "sha256": "36920c0f7a0ae00c2542579f9b600108f77de228a892417ebf8cb651123ad1e8",
+    "size": "912716876"
+  },
+  {
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/aarch64/images/Fedora-Phosh-40-1.14.aarch64.raw.xz",
+    "variant": "Spins",
+    "subvariant": "Phosh",
+    "sha256": "27a015a74dd7cdfd8a2a13cf0fec521e04f04249e5430e26bc698719f6df60b1",
+    "size": "2086621740"
+  },
+  {
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/aarch64/images/Fedora-SoaS-40-1.14.aarch64.raw.xz",
+    "variant": "Spins",
+    "subvariant": "SoaS",
+    "sha256": "a4cdd47d37438bbd90ddf1f9ecde7ed94765788381afa4a93412a22301014c87",
+    "size": "1720404580"
+  },
+  {
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Spins/aarch64/images/Fedora-Xfce-40-1.14.aarch64.raw.xz",
+    "variant": "Spins",
+    "subvariant": "Xfce",
+    "sha256": "8622a0f05cc09ec22bd63bc3712b552cee3512f2b135fa51d08a745e4b0169ce",
+    "size": "2282925736"
+  },
+  {
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Onyx/x86_64/images/Fedora-Onyx-40_Beta.1.10.ociarchive",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Workstation/x86_64/iso/Fedora-Workstation-Live-osb-40-1.14.x86_64.iso",
+    "variant": "Workstation",
+    "subvariant": "Workstation",
+    "sha256": "8d3cb4d99f27eb932064915bc9ad34a7529d5d073a390896152a8a899518573f",
+    "size": "2623733760"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-40-1.14.iso",
+    "variant": "Workstation",
+    "subvariant": "Workstation",
+    "sha256": "dd1faca950d1a8c3d169adf2df4c3644ebb62f8aac04c401f2393e521395d613",
+    "size": "2295853056"
+  },
+  {
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Workstation/aarch64/images/Fedora-Workstation-40-1.14.aarch64.raw.xz",
+    "variant": "Workstation",
+    "subvariant": "Workstation",
+    "sha256": "edaaf8e78db25c81c5600ef65b1ed2c85417ba7b51c3a5785d5acff6e8c90721",
+    "size": "2622667416"
+  },
+  {
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Workstation/aarch64/iso/Fedora-Workstation-Live-osb-40-1.14.aarch64.iso",
+    "variant": "Workstation",
+    "subvariant": "Workstation",
+    "sha256": "ebb1edbf16da88ed3fb804eca01625fb4341f59ce747c6b89ec00af58a9a6158",
+    "size": "2582759424"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Onyx/x86_64/images/Fedora-Onyx-40.1.14.ociarchive",
     "variant": "Onyx",
-    "subvariant": ""
+    "subvariant": "Onyx"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/test/40_Beta/Onyx/x86_64/iso/Fedora-Onyx-ostree-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Onyx/x86_64/iso/Fedora-Onyx-ostree-x86_64-40-1.14.iso",
     "variant": "Onyx",
     "subvariant": "Onyx",
-    "sha256": "e275969ebde33cecb7c87ff2ca923b6fe0a360eb62644351d2ff72c2f93f6d30",
-    "size": "2674311168"
+    "sha256": "b196159ab8bf2ced06204a13925f330546f9b0f3db253f6b399a3a5dac517acb",
+    "size": "2701541376"
   },
   {
-    "version": "40 Beta",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/images/Fedora-Python-Classroom-Vagrant-40_Beta-1.10.x86_64.vagrant-virtualbox.box",
+    "version": "40",
+    "arch": "aarch64",
+    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Labs/aarch64/images/Fedora-Python-Classroom-40-1.14.aarch64.raw.xz",
     "variant": "Labs",
     "subvariant": "Python_Classroom",
-    "sha256": "d8f2d239985fdc333d1556bca6059c3efddc9a79a38deaeaaa9c2fea2f20210e",
-    "size": "1569689600"
+    "sha256": "9c3f177cf24a802eaf8ce616b3b8e349b2850f7ea9692c05e9bf068255de1a7a",
+    "size": "2709743384"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/images/Fedora-Python-Classroom-Vagrant-40_Beta-1.10.x86_64.vagrant-libvirt.box",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/images/Fedora-Python-Classroom-Vagrant-40-1.14.x86_64.vagrant-libvirt.box",
     "variant": "Labs",
     "subvariant": "Python_Classroom",
-    "sha256": "846bce7eda651fb1da3cbe09697455dff606062596ee3ce1cc7dec9812300947",
-    "size": "1548498909"
+    "sha256": "163ed90b1c47d8428959c825ea92974fe153714b6c3ca438c91c0b316645baef",
+    "size": "1547788429"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/images/Fedora-Scientific-Vagrant-40_Beta-1.10.x86_64.vagrant-libvirt.box",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/images/Fedora-Python-Classroom-Vagrant-40-1.14.x86_64.vagrant-virtualbox.box",
+    "variant": "Labs",
+    "subvariant": "Python_Classroom",
+    "sha256": "aa4da25b27e82add30e5eb0c8526af28963eafcde6f3c7c6a6a96122819e1389",
+    "size": "1569054720"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/images/Fedora-Scientific-Vagrant-40-1.14.x86_64.vagrant-libvirt.box",
     "variant": "Labs",
     "subvariant": "Scientific",
-    "sha256": "f18d8fa2b3983079724eb7edeef6cf546cf03de8f7201166feefe6c241d86138",
-    "size": "4926144018"
+    "sha256": "78c2cfe481c9ef549eca5808ffc9f0a21a85ad2bb4c444369740fd8d9dd32b6f",
+    "size": "4930855083"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/images/Fedora-Scientific-Vagrant-40_Beta-1.10.x86_64.vagrant-virtualbox.box",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/images/Fedora-Scientific-Vagrant-40-1.14.x86_64.vagrant-virtualbox.box",
     "variant": "Labs",
     "subvariant": "Scientific",
-    "sha256": "5c51d56c97d81c339d863552f1e119b454618ad341fff2152faaed4ef4edcc5f",
-    "size": "4982435840"
+    "sha256": "ab61c41a4199165ee85b00b1bb3b1f5c27f7d10603ab13e4116e6d27951406bf",
+    "size": "4987146240"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Astronomy_KDE",
-    "sha256": "1f0dff7a4de4ef52e1afba57c4eba06154aa13c6465256dd2a8e0637e975eedd",
-    "size": "4623587328"
+    "sha256": "af586cefa44b7f9c8b755c121e7d5c99f3d88beb39721daec7f3a626622b64fb",
+    "size": "4634284032"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Comp_Neuro-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Comp_Neuro-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Comp_Neuro",
-    "sha256": "f26d992cad844198933fdf6c2ae819041cca52e798c74433e73c1b6a205dc490",
-    "size": "3064027136"
+    "sha256": "3e17b61870224ca92f85cb031070c4a969a07ad7dacfaacbfd5b70ecb32331c1",
+    "size": "3074414592"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Games-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Games-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Games",
-    "sha256": "9b0d95ea81dc6a1f1d3124f4521cfc3757d0353882c6de1c47df94f685c8de8c",
-    "size": "6863560704"
+    "sha256": "d99ad7ec55a27393dcb846a333b0e74d5d8b0c70a335b4a0a98ff6e850c852aa",
+    "size": "6890553344"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Jam_KDE-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Jam_KDE-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Jam_KDE",
-    "sha256": "c06af5759523de23c0f0bf07e810b4a4d361eec0a7b6a4358e4795feb6b06303",
-    "size": "3511683072"
+    "sha256": "816a7d24aa1afc5e875a33e319204a7cd12a7780ae33ab019ee1c5141941611f",
+    "size": "3520172032"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Python-Classroom-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Python-Classroom-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Python_Classroom",
-    "sha256": "1a12da509e3c5532d530445c53dbc7a12188c45656f66c69cfa369971d87ceeb",
-    "size": "2335234048"
+    "sha256": "5893394eccd8228f9e4f708e76f6cdb77f61ba79c6d19a1dd4a11776e824afe6",
+    "size": "2346051584"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Scientific_KDE-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Robotics-Live-x86_64-40-1.14.iso",
+    "variant": "Labs",
+    "subvariant": "Robotics",
+    "sha256": "c8de28ddb4667d57dc9527d2a7b445ec77861e129b3354251068a0ca9a2e640d",
+    "size": "3168759808"
+  },
+  {
+    "version": "40",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Scientific_KDE-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Scientific_KDE",
-    "sha256": "c78dd6bd266f3fdcc07b6657ae548000b6bb53e635322b39c16b8488b261d5d5",
-    "size": "5536098304"
+    "sha256": "4cfb06b40a5b7fbbc46794a8a1fa89f819712681fc2b8d23d3beb4b394cea0db",
+    "size": "5545820160"
   },
   {
-    "version": "40 Beta",
+    "version": "40",
     "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/test/40_Beta/Labs/x86_64/iso/Fedora-Security-Live-x86_64-40_Beta-1.10.iso",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/40/Labs/x86_64/iso/Fedora-Security-Live-x86_64-40-1.14.iso",
     "variant": "Labs",
     "subvariant": "Security",
-    "sha256": "afaa134417725a7ba96e8ecd759035b255190fe2a402543a3e63026ed31e0340",
-    "size": "2437244928"
+    "sha256": "2a2e55d2fb08c905e945e259d8b5cab55701c3dbdec717d178d7fb4a5da45608",
+    "size": "2463766528"
   },
   {
     "version": "39",
@@ -936,6 +1008,13 @@
   },
   {
     "version": "39",
+    "arch": "x86_64",
+    "link": "https://download.fedoraproject.org/pub/alt/releases/39/respins/Sericea/x86_64/Fedora-Sericea-ostree-x86_64-39-1.5-respin.iso",
+    "variant": "Fedora",
+    "subvariant": "Sericea"
+  },
+  {
+    "version": "39",
     "arch": "ppc64",
     "link": "https://download.fedoraproject.org/pub/alt/releases/39/respins/Kinoite/ppc64le/Fedora-Kinoite-ostree-ppc64le-39-1.5-respin.iso",
     "variant": "Fedora",
@@ -1093,509 +1172,5 @@
     "subvariant": "IoT",
     "sha256": "0cc60fec1790a7a455256004035de4c4c55988bedcf7ef33c3a8ec20f75920cc",
     "size": "1302091776"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-GCP-38-1.6.x86_64.tar.gz",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "6bf0818b1a178d530cac314f033102f4a1e995280564da8d1071dc52e8c6eefa",
-    "size": "502959652"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.qcow2",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "d334670401ff3d5b4129fcc662cf64f5a6e568228af59076cc449a4945318482",
-    "size": "497287168"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-38-1.6.x86_64.raw.xz",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "5fe502369737c77e8ed074803ea0e6b34365ed274701f47327fd1f5eb45474ce",
-    "size": "393441776"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-38-1.6.x86_64.vagrant-libvirt.box",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "67aeda42f7f302907cc4229affe5444fd74398cc63698ede64488f2c7c5be2d7",
-    "size": "484047550"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-38-1.6.x86_64.vagrant-virtualbox.box",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "6f597d98ce112167843536c1847e76c96531a1d15598758d0e8107830c76eecd",
-    "size": "495882240"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.qcow2",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "ad71d22104a16e4f9efa93e61e8c7bce28de693f59c802586abbe85e9db55a65",
-    "size": "499056640"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Cloud/aarch64/images/Fedora-Cloud-Base-38-1.6.aarch64.raw.xz",
-    "variant": "Cloud",
-    "subvariant": "Cloud_Base",
-    "sha256": "58ea3280f8fcf8adea81ec2d7d26afcc75989ad4021d4e1de22a88e9714477a8",
-    "size": "394203716"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Container/x86_64/images/Fedora-Container-Base-38-1.6.x86_64.tar.xz",
-    "variant": "Container",
-    "subvariant": "Container_Base",
-    "sha256": "366fe4a6a6d98241704f22d0b2e6591ee9ad502d83019f9c580a7b2fe9f5068b",
-    "size": "44741412"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Container/x86_64/images/Fedora-Container-Minimal-Base-38-1.6.x86_64.tar.xz",
-    "variant": "Container",
-    "subvariant": "Container_Minimal_Base",
-    "sha256": "5077fc68461aa9ccd4f419e76dc46b7efdb90a71d5b1c69da382c1a24fb11886",
-    "size": "28454572"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Container/aarch64/images/Fedora-Container-Base-38-1.6.aarch64.tar.xz",
-    "variant": "Container",
-    "subvariant": "Container_Base",
-    "sha256": "55600f9db2dad6682466ef7f6df507f44667ee5a1a74789d22928556f32f41f6",
-    "size": "42351620"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Container/aarch64/images/Fedora-Container-Minimal-Base-38-1.6.aarch64.tar.xz",
-    "variant": "Container",
-    "subvariant": "Container_Minimal_Base",
-    "sha256": "c3cb3263e8e7bca952adcca5dbff7f8e0f585c448c608b31fe1fb0c330ff421f",
-    "size": "26114300"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-38-1.6.iso",
-    "variant": "Everything",
-    "subvariant": "Everything",
-    "sha256": "4d042dedc8886856db10bc882074b84dcce52f829ea7b3f31d8031db8d84df20",
-    "size": "718284800"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Everything/aarch64/iso/Fedora-Everything-netinst-aarch64-38-1.6.iso",
-    "variant": "Everything",
-    "subvariant": "Everything",
-    "sha256": "9fc3d1a6390c1c9c0128345506658019e011c66dd9cffac65817eb72ba71e716",
-    "size": "687859712"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Kinoite/x86_64/iso/Fedora-Kinoite-ostree-x86_64-38-1.6.iso",
-    "variant": "Kinoite",
-    "subvariant": "Kinoite",
-    "sha256": "5415e61ae43253a61e267aaf21cc62de54ee80f2f0b59351f88feef47dab5eeb",
-    "size": "2786338816"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Kinoite/aarch64/iso/Fedora-Kinoite-ostree-aarch64-38-1.6.iso",
-    "variant": "Kinoite",
-    "subvariant": "Kinoite",
-    "sha256": "e1507737781810278a7750fc1841b42b60c5035e0d274e858dc4ccccb36cd159",
-    "size": "2684594176"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/x86_64/images/Fedora-Server-KVM-38-1.6.x86_64.qcow2",
-    "variant": "Server",
-    "subvariant": "Server_KVM",
-    "sha256": "fe07c4885c6a224e5527c6eccd0ada07c858a0eec2135e1c9ccd02c26eec408d",
-    "size": "629276672"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/x86_64/iso/Fedora-Server-dvd-x86_64-38-1.6.iso",
-    "variant": "Server",
-    "subvariant": "Server",
-    "sha256": "66b52d7cb39386644cd740930b0bef0a5a2f2be569328fef6b1f9b3679fdc54d",
-    "size": "2438201344"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/x86_64/iso/Fedora-Server-netinst-x86_64-38-1.6.iso",
-    "variant": "Server",
-    "subvariant": "Server",
-    "sha256": "192af621553aa32154697029e34cbe30152a9e23d72d55f31918b166979bbcf5",
-    "size": "718336000"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/aarch64/images/Fedora-Server-38-1.6.aarch64.raw.xz",
-    "variant": "Server",
-    "subvariant": "Server",
-    "sha256": "11e8880908c1a147d8c8d41fd48cfd445dc555b6a8fddaa511710951b882fb1b",
-    "size": "1576650748"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/aarch64/images/Fedora-Server-KVM-38-1.6.aarch64.qcow2",
-    "variant": "Server",
-    "subvariant": "Server_KVM",
-    "sha256": "30a1ce459f4ae4f51ca31d5fbb7827e855b9b446df2de1fe01ebabc39fde3eb2",
-    "size": "592576512"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/aarch64/iso/Fedora-Server-dvd-aarch64-38-1.6.iso",
-    "variant": "Server",
-    "subvariant": "Server",
-    "sha256": "0b40485d74fc60c0a78f071396aba78fafb2f8f3b1ab4cbc3388bda82f764f9b",
-    "size": "2281897984"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Server/aarch64/iso/Fedora-Server-netinst-aarch64-38-1.6.iso",
-    "variant": "Server",
-    "subvariant": "Server",
-    "sha256": "0cbc11231f3e27b3e29c88936d0eca289546f8c7eba53f39b81ea575ceba454a",
-    "size": "687929344"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Silverblue/x86_64/iso/Fedora-Silverblue-ostree-x86_64-38-1.6.iso",
-    "variant": "Silverblue",
-    "subvariant": "Silverblue",
-    "sha256": "0569d072cddb64fa08773d9f7649f2f1f55a4c04228d47042d405a6a10ffe1c6",
-    "size": "3175862272"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-MATE_Compiz-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "Mate",
-    "sha256": "29a9b062c2a4b4444f2b2cfd20048cfc2d0d40b36e5ae4535573ce35a554ea12",
-    "size": "2224752640"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-Budgie-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "Budgie",
-    "sha256": "6fa95cfd33cd57bec96f8c80d258f1d6a7a6adf8cc20d34245fb4cd2448e33ba",
-    "size": "1967298560"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-Cinnamon-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "Cinnamon",
-    "sha256": "d683f5b5be304b187d96be30738618ce1fa5c0e18a6662ce219b17bbb41b9865",
-    "size": "2304890880"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-KDE-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "KDE",
-    "sha256": "984e65fd81fe62dcc1ef2ebc0cfda1ca1659221e5e2fb87cf715badd0a047f00",
-    "size": "2408269824"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-LXDE-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "LXDE",
-    "sha256": "ebcd4c807bb2bfac87fe9015c921797ad6cff583f3cf46808afd8d45269aa619",
-    "size": "1455536128"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-LXQt-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "LXQt",
-    "sha256": "f8abfc399a4a346b31fb8cb0b8a6cfe20a5b6de2ab08ee455815817a5a7b6773",
-    "size": "1486770176"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-SoaS-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "SoaS",
-    "sha256": "56db9cfda255ff2ebf27b69b09c99f43285f88143d09fc480a8452023511cbf9",
-    "size": "1236578304"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-Sway-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "Sway",
-    "sha256": "110fdb40f42554e90f444f0d86f5b515708aa92d3e7c2931aee1d7df7ea1c491",
-    "size": "1555744768"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-Xfce-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "Xfce",
-    "sha256": "80363bfeae9573f2b2de320981404d5b4bdf49ad095a4d28f3c620afb73ff7fc",
-    "size": "1683156992"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Spins/x86_64/iso/Fedora-i3-Live-x86_64-38-1.6.iso",
-    "variant": "Spins",
-    "subvariant": "i3",
-    "sha256": "f2ca8aed269b8a52e1640faca2252072db548b255b253416198437cdaf2bbca1",
-    "size": "1438853120"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-38-1.6.iso",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "7a444a2e19012023bf0b015ae30135bafc5fd20f4f333310d42b118745093992",
-    "size": "2099451904"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Workstation/aarch64/images/Fedora-Workstation-38-1.6.aarch64.raw.xz",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "575f0974933caf9cc5161d1db73f22dde33e538cfe6bd2a68f65dbb322f03578",
-    "size": "4080790616"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Workstation/aarch64/iso/Fedora-Workstation-Live-aarch64-38-1.6.iso",
-    "variant": "Workstation",
-    "subvariant": "Workstation",
-    "sha256": "36e48904d5dd93d0bbbd9bc6087cb4025f25e2859fe45c93dda0f0e3e082387e",
-    "size": "2017744896"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/fedora/linux/releases/38/Sericea/x86_64/iso/Fedora-Sericea-ostree-x86_64-38-1.6.iso",
-    "variant": "Sericea",
-    "subvariant": "Sericea",
-    "sha256": "eb1c9a1eb369e506e555fd82033e108299e88e1f47340519dae9b6562f4fa934",
-    "size": "2197972992"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/images/Fedora-Python-Classroom-Vagrant-38-1.6.x86_64.vagrant-libvirt.box",
-    "variant": "Labs",
-    "subvariant": "Python_Classroom",
-    "sha256": "9217d38c5788e68b6fee97966cf617715207b016ef3b540f0ce1c0feec361224",
-    "size": "1394688314"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/images/Fedora-Python-Classroom-Vagrant-38-1.6.x86_64.vagrant-virtualbox.box",
-    "variant": "Labs",
-    "subvariant": "Python_Classroom",
-    "sha256": "518686ff2374e7ba37b894cc5a3a7ef79f104aecb8424f7ca69e2fdeff8daf78",
-    "size": "1414041600"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/images/Fedora-Scientific-Vagrant-38-1.6.x86_64.vagrant-libvirt.box",
-    "variant": "Labs",
-    "subvariant": "Scientific",
-    "sha256": "c65eff049ea992fd7ca231c0334a4852eb417dfb3270ec92d9036859a98131ac",
-    "size": "4186970434"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/images/Fedora-Scientific-Vagrant-38-1.6.x86_64.vagrant-virtualbox.box",
-    "variant": "Labs",
-    "subvariant": "Scientific",
-    "sha256": "2d614cf23d817d0bb1636e822927e3a4b94ea242b5dd93b627fc41fa2259590b",
-    "size": "4235796480"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Astronomy_KDE-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Astronomy_KDE",
-    "sha256": "630cc501bfc28162a0f37dae7f96f668085f906ad7db44b118fe6cad83205dc3",
-    "size": "5081790464"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Comp_Neuro-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Comp_Neuro",
-    "sha256": "05fcc0d8cb8cda468257b838ec2a59f246e846d0867fea68737e32a05c7c2b81",
-    "size": "2869561344"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Design_suite-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Design_suite",
-    "sha256": "5cff090c452f6b479a912528d4b03fe7dae199e25c921b8f064b313da0495654",
-    "size": "3750504448"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Games-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Games",
-    "sha256": "ad8efc4a458986809de6dc07bd291f12c8aeb802ad01616c0ca87b4abd35aae5",
-    "size": "6503419904"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Jam_KDE-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Jam_KDE",
-    "sha256": "fad3a48a9df666880a26c1f567874b164a3535df3655dcf21aebe4106a3d12c3",
-    "size": "3145064448"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Python-Classroom-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Python_Classroom",
-    "sha256": "597732906538ee25405613d7ae0af1a50d78db5fc794a2f7dd06a7af15fa4e1c",
-    "size": "2134595584"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Robotics-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Robotics",
-    "sha256": "eda4b00cf5a9c433831017cf12d5ffe16aa311a6b957b214aaa1767f53af8066",
-    "size": "3157374976"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Scientific_KDE-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Scientific_KDE",
-    "sha256": "ee5a6b686a12e7b16727143f8b6747642bdcaaa9708d1e539f1ce8afdc2bded1",
-    "size": "4805101568"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/releases/38/Labs/x86_64/iso/Fedora-Security-Live-x86_64-38-1.6.iso",
-    "variant": "Labs",
-    "subvariant": "Security",
-    "sha256": "6c02e0454ff9fa78d0bd16f1f443432092436a4082723b6805f5419e75634b8d",
-    "size": "2254899200"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/alt/iot/38/IoT/aarch64/images/Fedora-IoT-38.20230419.2-20230419.2.aarch64.raw.xz",
-    "variant": "IoT",
-    "subvariant": "IoT",
-    "sha256": "264f07366542415ffc30f69689de6d0525fc8ab04dc6be56d8174b1ff8b98353",
-    "size": "751943868"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/alt/iot/38/IoT/aarch64/iso/Fedora-IoT-ostree-38.20230419.2-20230419.2.aarch64.iso",
-    "variant": "IoT",
-    "subvariant": "IoT",
-    "sha256": "9fd1a242df44f2dbadf764da2a1fa9840c2c8405d49be963046caa7c968f72c0",
-    "size": "2402134016"
-  },
-  {
-    "version": "38",
-    "arch": "aarch64",
-    "link": "https://download.fedoraproject.org/pub/alt/iot/38/IoT/aarch64/iso/Fedora-IoT-ostree-aarch64-38-20230419.2.iso",
-    "variant": "IoT",
-    "subvariant": "IoT",
-    "sha256": "f8809a9365bb4bfe477b352b3815c56b0153ab7a7e62fac8b6f68dce7a2a9359",
-    "size": "1337843712"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/iot/38/IoT/x86_64/images/Fedora-IoT-38.20230419.2-20230419.2.x86_64.raw.xz",
-    "variant": "IoT",
-    "subvariant": "IoT",
-    "sha256": "f580ad64f2d16fc284d0f3f0a669bc0ee2db2877d2ffd0d5b11fac248f3d4602",
-    "size": "705014016"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/iot/38/IoT/x86_64/iso/Fedora-IoT-ostree-38.20230419.2-20230419.2.x86_64.iso",
-    "variant": "IoT",
-    "subvariant": "IoT",
-    "sha256": "5d854ad9747c38ee222bd2ac1710a724cb50b654dbc9b64ca5d6998b1b368729",
-    "size": "2382364672"
-  },
-  {
-    "version": "38",
-    "arch": "x86_64",
-    "link": "https://download.fedoraproject.org/pub/alt/iot/38/IoT/x86_64/iso/Fedora-IoT-ostree-x86_64-38-20230419.2.iso",
-    "variant": "IoT",
-    "subvariant": "IoT",
-    "sha256": "6f22609cb540e684f0758ad334b1f4e3b31bae54e21a2d2b8d4fc08b35f99c36",
-    "size": "1327953920"
   }
 ]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Starting with Fedora 40 a new filename format is used. The Fedora gatherer is updated to be compatible with the old and new filename formats when parsing them to get additional unique tags for a containerdisk.

Because Fedora is now publishing Cloud_Base and Cloud_Base_UKI
subvariants under the Cloud variant of Fedora, a filter for the
Cloud_Base subvariant is added. This avoids creating Fedora
containerdisks with more than a single image per architecture.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
