### PR TITLE
golangci-lint: Bump to v1.59.1 and replace gomnd with mnd

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,7 +35,7 @@ linters-settings:
     min-complexity: 15
   goimports:
     local-prefixes: kubevirt.io/containerdisks
-  gomnd:
+  mnd:
     # don't include the "operation" and "assign"
     checks: argument,case,condition,return
     ignored-functions:
@@ -82,7 +82,7 @@ linters:
     - gofumpt
     - goheader
     - goimports
-    - gomnd
+    - mnd
     - goprintffuncname
     - gosec
     - gosimple

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ vendor:
 	go mod vendor
 
 GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
-GOLANGCI_LINT_VERSION ?= v1.57.2
+GOLANGCI_LINT_VERSION ?= v1.59.1
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
/cc @0xFelix 

**What this PR does / why we need it**:

We've seen some slowness with `v1.57.2`  so this change bumps to `v1.59.1` and handles the deprecation/rename of `gomnd` to `mnd`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
