### PR TITLE
opensuse: Add default instance type and preference ENV vars

### DIFF
--- a/artifacts/opensuse/leap/leap.go
+++ b/artifacts/opensuse/leap/leap.go
@@ -14,9 +14,10 @@ import (
 )
 
 type leap struct {
-	Arch    string
-	Version string
-	getter  http.Getter
+	Arch         string
+	Version      string
+	getter       http.Getter
+	envVariables map[string]string
 }
 
 var _ api.Artifact = &leap{}
@@ -50,6 +51,7 @@ func (l *leap) Metadata() *api.Metadata {
 		ExampleUserData: docs.UserData{
 			Username: "opensuse",
 		},
+		EnvVariables: l.envVariables,
 	}
 }
 
@@ -72,10 +74,11 @@ func (l *leap) Tests() []api.ArtifactTest {
 	}
 }
 
-func New(arch, version string) *leap {
+func New(arch, version string, envVariables map[string]string) *leap {
 	return &leap{
-		Arch:    arch,
-		Version: version,
-		getter:  &http.HTTPGetter{},
+		Arch:         arch,
+		Version:      version,
+		getter:       &http.HTTPGetter{},
+		envVariables: envVariables,
 	}
 }

--- a/artifacts/opensuse/leap/leap_test.go
+++ b/artifacts/opensuse/leap/leap_test.go
@@ -7,14 +7,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/testutil"
 )
 
 var _ = Describe("OpenSUSE Leap", func() {
 	DescribeTable("Inspect should be able to parse checksum files",
-		func(arch, version, mockFile string, details *api.ArtifactDetails, metadata *api.Metadata) {
-			c := New(arch, version)
+		func(arch, version, mockFile string, envVariables map[string]string, details *api.ArtifactDetails, metadata *api.Metadata) {
+			c := New(arch, version, envVariables)
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
@@ -22,6 +23,10 @@ var _ = Describe("OpenSUSE Leap", func() {
 			Expect(c.Metadata()).To(Equal(metadata))
 		},
 		Entry("leap:15.6 x86_64", "x86_64", "15.6", "testdata/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2.sha256",
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "opensuse.leap",
+			},
 			&api.ArtifactDetails{
 				SHA256Sum:         "0f7f09a9a083088b51aa365fe0e4310e6b156c2153d6aa03a77b81eee884e52a",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2",
@@ -34,9 +39,14 @@ var _ = Describe("OpenSUSE Leap", func() {
 				ExampleUserData: docs.UserData{
 					Username: "opensuse",
 				},
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "opensuse.leap",
+				},
 			},
 		),
 		Entry("leap:15.6 aarch64", "aarch64", "15.6", "testdata/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2.sha256",
+			nil,
 			&api.ArtifactDetails{
 				SHA256Sum:         "d2ff40176f8823ab869bf4d728f827ffd6c7f180940b9ccca865be6dc20b06dd",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2",
@@ -52,6 +62,10 @@ var _ = Describe("OpenSUSE Leap", func() {
 			},
 		),
 		Entry("leap:15.5 x86_64", "x86_64", "15.5", "testdata/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2.sha256",
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "opensuse.leap",
+			},
 			&api.ArtifactDetails{
 				SHA256Sum:         "46e63b73fadc17c8b38ff83a45ebf3a736b86310e440ac1bfb123a420af1161f",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2",
@@ -64,9 +78,14 @@ var _ = Describe("OpenSUSE Leap", func() {
 				ExampleUserData: docs.UserData{
 					Username: "opensuse",
 				},
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "opensuse.leap",
+				},
 			},
 		),
 		Entry("leap:15.5 aarch64", "aarch64", "15.5", "testdata/openSUSE-Leap-15.5-Minimal-VM.aarch64-Cloud.qcow2.sha256",
+			nil,
 			&api.ArtifactDetails{
 				SHA256Sum:         "3560ca0845d797880a1a36ca84b52a6ba1d0bb1e153913312c5e9f3c9cfda56a",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.aarch64-Cloud.qcow2",

--- a/artifacts/opensuse/tumbleweed/tumbleweed.go
+++ b/artifacts/opensuse/tumbleweed/tumbleweed.go
@@ -16,10 +16,11 @@ import (
 )
 
 type tumbleweed struct {
-	Arch       string
-	variant    string
-	subVariant string
-	getter     http.Getter
+	Arch         string
+	variant      string
+	subVariant   string
+	getter       http.Getter
+	envVariables map[string]string
 }
 
 var _ api.Artifact = &tumbleweed{}
@@ -62,6 +63,7 @@ func (t *tumbleweed) Metadata() *api.Metadata {
 		ExampleUserData: docs.UserData{
 			Username: "opensuse",
 		},
+		EnvVariables: t.envVariables,
 	}
 }
 
@@ -84,11 +86,12 @@ func (t *tumbleweed) Tests() []api.ArtifactTest {
 	}
 }
 
-func New(arch string) *tumbleweed {
+func New(arch string, envVariables map[string]string) *tumbleweed {
 	return &tumbleweed{
-		Arch:       arch,
-		variant:    "openSUSE-Tumbleweed-Minimal-VM",
-		subVariant: "Cloud",
-		getter:     &http.HTTPGetter{},
+		Arch:         arch,
+		variant:      "openSUSE-Tumbleweed-Minimal-VM",
+		subVariant:   "Cloud",
+		getter:       &http.HTTPGetter{},
+		envVariables: envVariables,
 	}
 }

--- a/artifacts/opensuse/tumbleweed/tumbleweed_test.go
+++ b/artifacts/opensuse/tumbleweed/tumbleweed_test.go
@@ -8,14 +8,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/testutil"
 )
 
 var _ = Describe("OpenSUSE Tumbleweed", func() {
 	DescribeTable("Inspect should be able to parse checksum files",
-		func(arch, mockFile string, details *api.ArtifactDetails, metadata *api.Metadata) {
-			c := New(arch)
+		func(arch, mockFile string, envVariables map[string]string, details *api.ArtifactDetails, metadata *api.Metadata) {
+			c := New(arch, envVariables)
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
@@ -23,6 +24,10 @@ var _ = Describe("OpenSUSE Tumbleweed", func() {
 			Expect(c.Metadata()).To(Equal(metadata))
 		},
 		Entry("tumbleweed:1 x86_64", "x86_64", "testdata/tumbleweed.SHA256SUM",
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "opensuse.tumbleweed",
+			},
 			&api.ArtifactDetails{
 				SHA256Sum:         "e8150b4a7ce5c56587492c930af094236c7a095149d714c015e6860ce6c58e66",
 				DownloadURL:       "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-1.0.0-Cloud-Snapshot20240629.qcow2",
@@ -34,6 +39,10 @@ var _ = Describe("OpenSUSE Tumbleweed", func() {
 				Description: description,
 				ExampleUserData: docs.UserData{
 					Username: "opensuse",
+				},
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "opensuse.tumbleweed",
 				},
 			},
 		),

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -61,21 +61,21 @@ var staticRegistry = []Entry{
 	},
 	{
 		Artifacts: []api.Artifact{
-			tumbleweed.New("x86_64"),
+			tumbleweed.New("x86_64", defaultEnvVariables("u1.medium", "opensuse.tumbleweed")),
 		},
 		UseForDocs: true,
 	},
 	{
 		Artifacts: []api.Artifact{
-			leap.New("x86_64", "15.6"),
-			leap.New("aarch64", "15.6"),
+			leap.New("x86_64", "15.6", defaultEnvVariables("u1.medium", "opensuse.leap")),
+			leap.New("aarch64", "15.6", nil),
 		},
 		UseForDocs: true,
 	},
 	{
 		Artifacts: []api.Artifact{
-			leap.New("x86_64", "15.5"),
-			leap.New("aarch64", "15.5"),
+			leap.New("x86_64", "15.5", defaultEnvVariables("u1.medium", "opensuse.leap")),
+			leap.New("aarch64", "15.5", nil),
 		},
 	},
 	// for testing only


### PR DESCRIPTION
/hold
/cc @0xFelix 

**What this PR does / why we need it**:

With https://github.com/kubevirt/common-instancetypes/pull/193 in place we can now provide default instance types and prefrences for the recently introduced OpenSUSE containerdisks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
ENV variables for default instance types and preferences have been added to the `amd64` OpenSUSE Tumbleweed and Leap containerdisks.
```
