### PR TITLE
Add s390x Artifacts

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -195,6 +195,7 @@ const (
 	defaultInstancetype      = "u1.medium"
 	defaultPreferenceX86_64  = "fedora"
 	defaultPreferenceAarch64 = "fedora.arm64"
+	defaultPreferenceS390x   = "fedora.s390x"
 )
 
 func (f *fedora) setEnvVariables() {
@@ -208,6 +209,11 @@ func (f *fedora) setEnvVariables() {
 		f.EnvVariables = map[string]string{
 			common.DefaultInstancetypeEnv: defaultInstancetype,
 			common.DefaultPreferenceEnv:   defaultPreferenceAarch64,
+		}
+	case "s390x":
+		f.EnvVariables = map[string]string{
+			common.DefaultInstancetypeEnv: defaultInstancetype,
+			common.DefaultPreferenceEnv:   defaultPreferenceS390x,
 		}
 	}
 }
@@ -225,7 +231,7 @@ func New(release, arch string) *fedora {
 
 func NewGatherer() *fedoraGatherer {
 	return &fedoraGatherer{
-		Archs:      []string{"x86_64", "aarch64"},
+		Archs:      []string{"x86_64", "aarch64", "s390x"},
 		Variant:    "Cloud",
 		Subvariant: "Cloud_Base",
 		getter:     &http.HTTPGetter{},

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -28,6 +28,7 @@ var staticRegistry = []Entry{
 		Artifacts: []api.Artifact{
 			centosstream.New("9", "x86_64", &docs.UserData{Username: "cloud-user"}, defaultEnvVariables("u1.medium", "centos.stream9")),
 			centosstream.New("9", "aarch64", &docs.UserData{Username: "cloud-user"}, defaultEnvVariables("u1.medium", "centos.stream9")),
+			centosstream.New("9", "s390x", &docs.UserData{Username: "cloud-user"}, defaultEnvVariables("u1.medium", "centos.stream9")),
 		},
 		UseForDocs: true,
 	},
@@ -35,6 +36,7 @@ var staticRegistry = []Entry{
 		Artifacts: []api.Artifact{
 			ubuntu.New("24.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("24.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("24.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
 		UseForDocs: true,
 	},
@@ -42,6 +44,7 @@ var staticRegistry = []Entry{
 		Artifacts: []api.Artifact{
 			ubuntu.New("22.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("22.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("22.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
 		UseForDocs: false,
 	},
@@ -49,6 +52,7 @@ var staticRegistry = []Entry{
 		Artifacts: []api.Artifact{
 			ubuntu.New("20.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("20.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("20.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
 		UseForDocs: false,
 	},

--- a/pkg/architecture/arch.go
+++ b/pkg/architecture/arch.go
@@ -8,6 +8,8 @@ func GetImageArchitecture(arch string) string {
 		return "amd64"
 	case "aarch64":
 		return "arm64"
+	case "s390x":
+		return "s390x"
 	default:
 		panic(fmt.Sprintf("can't map unknown architecture %s to image architecture", arch))
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

I create this PR as part of the bigger effort to enable KubeVirt on s390x, a.k.a IBM Z ( please refer to  :  https://github.com/kubevirt/kubevirt/pull/10490 ). It appears that https://github.com/kubevirt/common-instancetypes/ depends on `containerdisks`.

Therefore I added "s390x" entries to existing Feodora, CentOS Stream and Ubuntu Artifact / registries.

I have not added any tests to either `artifacts/fedora/fedora_test.go` , `artifacts/centosstream/centos-stream_test.go`, or `artifacts/ubuntu/ubuntu_test.go`, because the tests appears to only verify the parsing function.

TO DO:

Discuss whether other Linux distros, e.g. OpenSUSE is needed for s390x.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
