### PR TITLE
feat(centos): Remove CentOS Stream 8 support

### DIFF
--- a/artifacts/centosstream/centos-stream.go
+++ b/artifacts/centosstream/centos-stream.go
@@ -51,7 +51,7 @@ func (c *centos) Metadata() *api.Metadata {
 func (c *centos) Inspect() (*api.ArtifactDetails, error) {
 	var baseURL string
 
-	if strings.HasPrefix(c.Version, "8") || strings.HasPrefix(c.Version, "9") || strings.HasPrefix(c.Version, "10") {
+	if strings.HasPrefix(c.Version, "9") || strings.HasPrefix(c.Version, "10") {
 		baseURL = fmt.Sprintf("https://cloud.centos.org/centos/%s-stream/%s/images/", c.Version, c.Arch)
 	} else {
 		panic(fmt.Sprintf("can't understand provided version: %q", c.Version))


### PR DESCRIPTION
**What this PR does / why we need it**:

Drops the support for CentOS Stream 8 images.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubevirt/containerdisks/issues/152

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Drops CentOS Stream 8 support.
```
