### PR TITLE
ci: test the CentOS Stream distribution in pipeline.sh

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -5,7 +5,7 @@ set -e -o pipefail
 make medius
 make cluster-up
 
-FOCUS=${FOCUS:-cirros:6.1}
+FOCUS=${FOCUS:-centos-stream:9}
 registry="$(./hack/kubevirtci.sh registry)"
 kubeconfig="$(./hack/kubevirtci.sh kubeconfig)"
 ./bin/medius images push --force --focus="${FOCUS}" --no-fail --dry-run=false --source-registry="${registry}" --insecure-skip-tls


### PR DESCRIPTION
CentOS Stream supports a wider range of architectures, making this change a logical step toward enhancing multiarch testing.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
