### PR TITLE
ci: set default kubevirtci provider to version 1.31

### DIFF
--- a/pipeline.sh
+++ b/pipeline.sh
@@ -2,10 +2,12 @@
 
 set -e -o pipefail
 
+export KUBEVIRT_PROVIDER=${KUBEVIRT_PROVIDER:-k8s-1.31}
+FOCUS=${FOCUS:-centos-stream:9}
+
 make medius
 make cluster-up
 
-FOCUS=${FOCUS:-centos-stream:9}
 registry="$(./hack/kubevirtci.sh registry)"
 kubeconfig="$(./hack/kubevirtci.sh kubeconfig)"
 ./bin/medius images push --force --focus="${FOCUS}" --no-fail --dry-run=false --source-registry="${registry}" --insecure-skip-tls


### PR DESCRIPTION
The kubevirtci provider version 1.31 is the first release that supports the s390x architecture.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
