### PR TITLE
fix: secure boot not enabled on s390x

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"regexp"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -98,6 +99,14 @@ func (f *fedora) Inspect() (*api.ArtifactDetails, error) {
 }
 
 func (f *fedora) VM(name, imgRef, userData string) *v1.VirtualMachine {
+	if runtime.GOARCH == "s390x" {
+		return docs.NewVM(
+			name,
+			imgRef,
+			docs.WithRng(),
+			docs.WithCloudInitNoCloud(userData),
+		)
+	}
 	return docs.NewVM(
 		name,
 		imgRef,


### PR DESCRIPTION
In Fedora, Secure Boot must be disabled to successfully run a new s390x VM.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
