### PR TITLE
fix: secure boot not enabled on s390x

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -46,7 +46,12 @@ type fedoraGatherer struct {
 	getter     http.Getter
 }
 
-const minimumVersion = 38
+const (
+	minimumVersion = 38
+	amd64Arch      = "x86_64"
+	arm64Arch      = "aarch64"
+	s390xArch      = "s390x"
+)
 
 //nolint:lll
 const description = `<img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3f/Fedora_logo.svg/240px-Fedora_logo.svg.png" alt="drawing" width="15"/> Fedora [Cloud](https://alt.fedoraproject.org/cloud/) images for KubeVirt.
@@ -99,6 +104,14 @@ func (f *fedora) Inspect() (*api.ArtifactDetails, error) {
 }
 
 func (f *fedora) VM(name, imgRef, userData string) *v1.VirtualMachine {
+	if f.Arch == s390xArch {
+		return docs.NewVM(
+			name,
+			imgRef,
+			docs.WithRng(),
+			docs.WithCloudInitNoCloud(userData),
+		)
+	}
 	return docs.NewVM(
 		name,
 		imgRef,
@@ -201,17 +214,17 @@ const (
 
 func (f *fedora) setEnvVariables() {
 	switch f.Arch {
-	case "x86_64":
+	case amd64Arch:
 		f.EnvVariables = map[string]string{
 			common.DefaultInstancetypeEnv: defaultInstancetype,
 			common.DefaultPreferenceEnv:   defaultPreferenceX86_64,
 		}
-	case "aarch64":
+	case arm64Arch:
 		f.EnvVariables = map[string]string{
 			common.DefaultInstancetypeEnv: defaultInstancetype,
 			common.DefaultPreferenceEnv:   defaultPreferenceAarch64,
 		}
-	case "s390x":
+	case s390xArch:
 		f.EnvVariables = map[string]string{
 			common.DefaultInstancetypeEnv: defaultInstancetype,
 			common.DefaultPreferenceEnv:   defaultPreferenceS390x,
@@ -232,7 +245,7 @@ func New(release, arch string) *fedora {
 
 func NewGatherer() *fedoraGatherer {
 	return &fedoraGatherer{
-		Archs:      []string{"x86_64", "aarch64", "s390x"},
+		Archs:      []string{amd64Arch, arm64Arch, s390xArch},
 		Variant:    "Cloud",
 		Subvariant: "Cloud_Base",
 		getter:     &http.HTTPGetter{},


### PR DESCRIPTION
In Fedora, Secure Boot must be disabled to successfully run a new s390x VM.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
