### PR TITLE
fix: disable Fedora 40 for s390x

### DIFF
--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -195,6 +195,10 @@ func (f *fedoraGatherer) releaseMatches(release *Release) bool {
 
 	for _, arch := range f.Archs {
 		if release.Arch == arch {
+			// The Fedora 40 images for s390x cannot boot, hence we avoid to build it.
+			if arch == "s390x" && release.Version == "40" {
+				return false
+			}
 			return version >= minimumVersion &&
 				release.Variant == f.Variant &&
 				release.Subvariant == f.Subvariant &&

--- a/artifacts/fedora/fedora_test.go
+++ b/artifacts/fedora/fedora_test.go
@@ -153,8 +153,15 @@ var _ = Describe("Fedora", func() {
 
 	It("Gather should be able to parse releases files", func() {
 		artifacts := [][]api.Artifact{
-			parsedRelease("40"),
-			parsedRelease("39"),
+			{
+				parsedRelease("40", "x86_64", defaultPreferenceX86_64),
+				parsedRelease("40", "aarch64", defaultPreferenceAarch64),
+			},
+			{
+				parsedRelease("39", "x86_64", defaultPreferenceX86_64),
+				parsedRelease("39", "aarch64", defaultPreferenceAarch64),
+				parsedRelease("39", "s390x", defaultPreferenceS390x),
+			},
 		}
 
 		c := NewGatherer()
@@ -165,42 +172,20 @@ var _ = Describe("Fedora", func() {
 	})
 })
 
+func parsedRelease(version, arch, defaultPreference string) api.Artifact {
+	return &fedora{
+		Version: version,
+		Arch:    arch,
+		Variant: "Cloud",
+		getter:  &http.HTTPGetter{},
+		EnvVariables: map[string]string{
+			common.DefaultInstancetypeEnv: defaultInstancetype,
+			common.DefaultPreferenceEnv:   defaultPreference,
+		},
+	}
+}
+
 func TestFedora(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Fedora Suite")
-}
-
-func parsedRelease(version string) []api.Artifact {
-	return []api.Artifact{
-		&fedora{
-			Version: version,
-			Arch:    "x86_64",
-			Variant: "Cloud",
-			getter:  &http.HTTPGetter{},
-			EnvVariables: map[string]string{
-				common.DefaultInstancetypeEnv: defaultInstancetype,
-				common.DefaultPreferenceEnv:   defaultPreferenceX86_64,
-			},
-		},
-		&fedora{
-			Version: version,
-			Arch:    "aarch64",
-			Variant: "Cloud",
-			getter:  &http.HTTPGetter{},
-			EnvVariables: map[string]string{
-				common.DefaultInstancetypeEnv: defaultInstancetype,
-				common.DefaultPreferenceEnv:   defaultPreferenceAarch64,
-			},
-		},
-		&fedora{
-			Version: version,
-			Arch:    "s390x",
-			Variant: "Cloud",
-			getter:  &http.HTTPGetter{},
-			EnvVariables: map[string]string{
-				common.DefaultInstancetypeEnv: defaultInstancetype,
-				common.DefaultPreferenceEnv:   defaultPreferenceS390x,
-			},
-		},
-	}
 }


### PR DESCRIPTION
The Fedora 40 image is currently unable to boot with qemu-system-s390x. As this issue likely requires a resolution at the image level, we can temporarily prevent the image from being built for this architecture.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
