### PR TITLE
feat: Add target architecture as a parameter for verification.

### DIFF
--- a/cmd/medius/common/options.go
+++ b/cmd/medius/common/options.go
@@ -34,8 +34,9 @@ type PublishImageOptions struct {
 }
 
 type VerifyImageOptions struct {
-	Registry  string
-	Namespace string
-	NoFail    bool
-	Timeout   int
+	Registry           string
+	Namespace          string
+	NoFail             bool
+	Timeout            int
+	TargetArchitecture string
 }


### PR DESCRIPTION
This feature allows users to override the automatic detection of the architecture based on the node. Additionally, it paves the way for future enhancements, such as the ability to skip certain verifications based on the specified target architecture.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
