### PR TITLE
feat(containerdisk): Add support for Debian containerdisk and sha512 checksums

### DIFF
--- a/artifacts/centosstream/centos-stream.go
+++ b/artifacts/centosstream/centos-stream.go
@@ -2,6 +2,7 @@ package centosstream
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"sort"
 	"strings"
@@ -91,7 +92,8 @@ func (c *centos) Inspect() (*api.ArtifactDetails, error) {
 
 	if checksum, exists := checksums[candidate]; exists {
 		return &api.ArtifactDetails{
-			SHA256Sum:            checksum,
+			Checksum:             checksum,
+			ChecksumHash:         sha256.New,
 			DownloadURL:          baseURL + candidate,
 			AdditionalUniqueTags: additionalTags,
 			ImageArchitecture:    architecture.GetImageArchitecture(c.Arch),

--- a/artifacts/centosstream/centos-stream_test.go
+++ b/artifacts/centosstream/centos-stream_test.go
@@ -21,12 +21,17 @@ var _ = Describe("CentosStream", func() {
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(got).To(Equal(details))
+			Expect(got.ChecksumHash).ToNot(BeNil())
+			Expect(got.Checksum).To(Equal(details.Checksum))
+			Expect(got.DownloadURL).To(Equal(details.DownloadURL))
+			Expect(got.AdditionalUniqueTags).To(Equal(details.AdditionalUniqueTags))
+			Expect(got.ImageArchitecture).To(Equal(details.ImageArchitecture))
+			Expect(got.Compression).To(Equal(details.Compression))
 			Expect(c.Metadata()).To(Equal(metadata))
 		},
 		Entry("centos-stream:9 x86_64", "9", "x86_64", "testdata/centos-stream9-x86_64.checksum",
 			&api.ArtifactDetails{
-				SHA256Sum:            "bcebdc00511d6e18782732570056cfbc7cba318302748bfc8f66be9c0db68142",
+				Checksum:             "bcebdc00511d6e18782732570056cfbc7cba318302748bfc8f66be9c0db68142",
 				DownloadURL:          "https://cloud.centos.org/centos/9-stream/x86_64/images/CentOS-Stream-GenericCloud-9-20211222.0.x86_64.qcow2",
 				AdditionalUniqueTags: []string{"9-20211222.0"},
 				ImageArchitecture:    "amd64",
@@ -54,7 +59,7 @@ var _ = Describe("CentosStream", func() {
 		),
 		Entry("centos-stream:9 aarch64", "9", "aarch64", "testdata/centos-stream9-aarch64.checksum",
 			&api.ArtifactDetails{
-				SHA256Sum:            "66dd927b7aa643b18ad21a9368571c6ef57cc381b4febc8934397b137f14b995",
+				Checksum:             "66dd927b7aa643b18ad21a9368571c6ef57cc381b4febc8934397b137f14b995",
 				DownloadURL:          "https://cloud.centos.org/centos/9-stream/aarch64/images/CentOS-Stream-GenericCloud-9-latest.aarch64.qcow2",
 				AdditionalUniqueTags: []string{"9-latest"},
 				ImageArchitecture:    "arm64",
@@ -82,7 +87,7 @@ var _ = Describe("CentosStream", func() {
 		),
 		Entry("centos-stream:9 s390x", "9", "s390x", "testdata/centos-stream9-s390x.checksum",
 			&api.ArtifactDetails{
-				SHA256Sum:            "17322e2562832b57bb2554a5b7056fba6d06db662728c487496d83845d7f016c",
+				Checksum:             "17322e2562832b57bb2554a5b7056fba6d06db662728c487496d83845d7f016c",
 				DownloadURL:          "https://cloud.centos.org/centos/9-stream/s390x/images/CentOS-Stream-GenericCloud-9-latest.s390x.qcow2",
 				AdditionalUniqueTags: []string{"9-latest"},
 				ImageArchitecture:    "s390x",
@@ -110,7 +115,7 @@ var _ = Describe("CentosStream", func() {
 		),
 		Entry("centos-stream:10 x86_64", "10", "x86_64", "testdata/centos-stream10-x86_64.checksum",
 			&api.ArtifactDetails{
-				SHA256Sum:            "3cb1310f39d92d34d0ea62c1d6f8943f47dce9df6937adb5bd26af8efa5d921d",
+				Checksum:             "3cb1310f39d92d34d0ea62c1d6f8943f47dce9df6937adb5bd26af8efa5d921d",
 				DownloadURL:          "https://cloud.centos.org/centos/10-stream/x86_64/images/CentOS-Stream-GenericCloud-10-latest.x86_64.qcow2",
 				AdditionalUniqueTags: []string{"10-latest"},
 				ImageArchitecture:    "amd64",
@@ -138,7 +143,7 @@ var _ = Describe("CentosStream", func() {
 		),
 		Entry("centos-stream:10 aarch64", "10", "aarch64", "testdata/centos-stream10-aarch64.checksum",
 			&api.ArtifactDetails{
-				SHA256Sum:            "dc929660b4e88eea4ad5f1dcf49c21405ab9462a898659228c938a89283ae93c",
+				Checksum:             "dc929660b4e88eea4ad5f1dcf49c21405ab9462a898659228c938a89283ae93c",
 				DownloadURL:          "https://cloud.centos.org/centos/10-stream/aarch64/images/CentOS-Stream-GenericCloud-10-latest.aarch64.qcow2",
 				AdditionalUniqueTags: []string{"10-latest"},
 				ImageArchitecture:    "arm64",
@@ -166,7 +171,7 @@ var _ = Describe("CentosStream", func() {
 		),
 		Entry("centos-stream:10 s390x", "10", "s390x", "testdata/centos-stream10-s390x.checksum",
 			&api.ArtifactDetails{
-				SHA256Sum:            "dc854a20aabbb7150ad8da3c2b39a1c9f810cf3270ec706837bf5bb80435c907",
+				Checksum:             "dc854a20aabbb7150ad8da3c2b39a1c9f810cf3270ec706837bf5bb80435c907",
 				DownloadURL:          "https://cloud.centos.org/centos/10-stream/s390x/images/CentOS-Stream-GenericCloud-10-latest.s390x.qcow2",
 				AdditionalUniqueTags: []string{"10-latest"},
 				ImageArchitecture:    "s390x",

--- a/artifacts/debian/debian.go
+++ b/artifacts/debian/debian.go
@@ -1,0 +1,162 @@
+package debian
+
+import (
+	"crypto/sha512"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/architecture"
+	"kubevirt.io/containerdisks/pkg/docs"
+	"kubevirt.io/containerdisks/pkg/http"
+	"kubevirt.io/containerdisks/pkg/tests"
+)
+
+type Annotations struct {
+	Digest string `json:"cloud.debian.org/digest"`
+}
+
+type ImageLabel struct {
+	ImageFormat string `json:"upload.cloud.debian.org/image-format"`
+	Version     string `json:"cloud.debian.org/version"`
+}
+
+type Metadata struct {
+	Annotations Annotations `json:"annotations"`
+	Labels      ImageLabel  `json:"labels"`
+}
+
+type Item struct {
+	Metadata Metadata `json:"metadata"`
+}
+
+type BuildData struct {
+	Items []Item `json:"items"`
+}
+
+type debian struct {
+	Arch            string
+	Version         string
+	VersionName     string
+	getter          http.Getter
+	ExampleUserData *docs.UserData
+	envVariables    map[string]string
+}
+
+const (
+	baseURLFmt  = "https://cloud.debian.org/images/cloud/%s/latest/"
+	baseNameFmt = "debian-%s-genericcloud-%s"
+	description = `Debian Generic Cloud images for KubeVirt.
+<br />
+<br />
+Visit [debian.org](https://cloud.debian.org/images/cloud/) to learn more about Debian project.`
+)
+
+func (d *debian) Metadata() *api.Metadata {
+	metadata := &api.Metadata{
+		Name:         "debian",
+		Version:      d.Version,
+		Description:  description,
+		Arch:         d.Arch,
+		EnvVariables: d.envVariables,
+	}
+
+	if d.ExampleUserData != nil {
+		metadata.ExampleUserData = *d.ExampleUserData
+	}
+
+	return metadata
+}
+
+func decodeChecksum(base64Checksum string) (string, error) {
+	base64Checksum = strings.TrimPrefix(base64Checksum, "sha512:")
+
+	rawBytes, err := base64.RawStdEncoding.DecodeString(base64Checksum)
+	if err != nil {
+		return "", fmt.Errorf("error decoding debian digest: %v", err)
+	}
+
+	return hex.EncodeToString(rawBytes), nil
+}
+
+func (d *debian) getBuildData(jsonURL string) (additionalTags []string, checksum string, err error) {
+	raw, err := d.getter.GetAll(jsonURL)
+	if err != nil {
+		return nil, "", fmt.Errorf("error downloading debian json file: %v", err)
+	}
+
+	var buildData BuildData
+	if json.Unmarshal(raw, &buildData) != nil {
+		return nil, "", fmt.Errorf("error decoding debian json file: %v", err)
+	}
+
+	if len(buildData.Items) == 0 {
+		return nil, "", fmt.Errorf("build debian data not found")
+	}
+
+	for _, item := range buildData.Items {
+		if item.Metadata.Labels.ImageFormat == "qcow2" {
+			additionalTags = append(additionalTags, d.Version+"-"+item.Metadata.Labels.Version)
+			checksum, err = decodeChecksum(item.Metadata.Annotations.Digest)
+			return additionalTags, checksum, err
+		}
+	}
+
+	return nil, "", fmt.Errorf("error locating the image information")
+}
+
+func (d *debian) Inspect() (*api.ArtifactDetails, error) {
+	if !strings.HasPrefix(d.Version, "11") && !strings.HasPrefix(d.Version, "12") {
+		return nil, fmt.Errorf("can't understand provided version %s", d.Version)
+	}
+
+	baseURL := fmt.Sprintf(baseURLFmt, d.VersionName) + fmt.Sprintf(baseNameFmt, d.Version, architecture.GetImageArchitecture(d.Arch))
+
+	additionalTags, checksum, err := d.getBuildData(baseURL + ".json")
+	if err != nil {
+		return nil, err
+	}
+
+	return &api.ArtifactDetails{
+		Checksum:             checksum,
+		ChecksumHash:         sha512.New,
+		DownloadURL:          baseURL + ".qcow2",
+		AdditionalUniqueTags: additionalTags,
+		ImageArchitecture:    architecture.GetImageArchitecture(d.Arch),
+	}, nil
+}
+
+func (d *debian) VM(name, imgRef, userData string) *v1.VirtualMachine {
+	return docs.NewVM(
+		name,
+		imgRef,
+		docs.WithRng(),
+		docs.WithCloudInitNoCloud(userData),
+	)
+}
+
+func (d *debian) UserData(data *docs.UserData) string {
+	return docs.CloudInit(data)
+}
+
+func (d *debian) Tests() []api.ArtifactTest {
+	return []api.ArtifactTest{
+		tests.SSH,
+	}
+}
+
+func New(version, versionName, arch string, exampleUserData *docs.UserData, envVariables map[string]string) *debian {
+	return &debian{
+		Version:         version,
+		Arch:            arch,
+		VersionName:     versionName,
+		getter:          &http.HTTPGetter{},
+		ExampleUserData: exampleUserData,
+		envVariables:    envVariables,
+	}
+}

--- a/artifacts/debian/debian_test.go
+++ b/artifacts/debian/debian_test.go
@@ -1,0 +1,130 @@
+package debian
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/docs"
+	"kubevirt.io/containerdisks/testutil"
+)
+
+var _ = Describe("Debian", func() {
+	DescribeTable("Inspect should be able to parse checksum files",
+		func(release, versionName, arch, mockFile string, details *api.ArtifactDetails,
+			exampleUserData *docs.UserData, envVariables map[string]string, metadata *api.Metadata,
+		) {
+			c := New(release, versionName, arch, exampleUserData, envVariables)
+			c.getter = testutil.NewMockGetter(mockFile)
+			got, err := c.Inspect()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(got.ChecksumHash).ToNot(BeNil())
+			Expect(got.Checksum).To(Equal(details.Checksum))
+			Expect(got.DownloadURL).To(Equal(details.DownloadURL))
+			Expect(got.AdditionalUniqueTags).To(Equal(details.AdditionalUniqueTags))
+			Expect(got.ImageArchitecture).To(Equal(details.ImageArchitecture))
+			Expect(got.Compression).To(Equal(details.Compression))
+			Expect(c.Metadata()).To(Equal(metadata))
+			Expect(c.Metadata()).To(Equal(metadata))
+		},
+		Entry("debian:11 x86_64", "11", "bullseye", "x86_64", "testdata/debian-11-genericcloud-amd64.json",
+			&api.ArtifactDetails{
+				Checksum: "3c08356d6860f987089c14b45953fb1f266d1b1b50dd086744925e2ed4113b804e848a8b1b46614febc48cd" +
+					"e759f18e824b76bfb02618ed6b3d06ed15ea99283",
+				DownloadURL:          "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-amd64.qcow2",
+				ImageArchitecture:    "amd64",
+				AdditionalUniqueTags: []string{"11-20250303-2040"},
+			},
+			&docs.UserData{
+				Username: "debian",
+			},
+			nil,
+			&api.Metadata{
+				Name:        "debian",
+				Version:     "11",
+				Arch:        "x86_64",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "debian",
+				},
+				EnvVariables: nil,
+			},
+		),
+		Entry("debian:11 aarch64", "11", "bullseye", "aarch64", "testdata/debian-11-genericcloud-arm64.json",
+			&api.ArtifactDetails{
+				Checksum: "c1a1645cf37ce628a8734bb25dce09fcd0858865302635ce0ae88b2da23bb615da43d483984709d743cd6b6" +
+					"b45d56d88e9f6800f0b3110ba1b09c01b990342f3",
+				DownloadURL:          "https://cloud.debian.org/images/cloud/bullseye/latest/debian-11-genericcloud-arm64.qcow2",
+				ImageArchitecture:    "arm64",
+				AdditionalUniqueTags: []string{"11-20250303-2040"},
+			},
+			&docs.UserData{
+				Username: "debian",
+			},
+			nil,
+			&api.Metadata{
+				Name:        "debian",
+				Version:     "11",
+				Arch:        "aarch64",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "debian",
+				},
+				EnvVariables: nil,
+			},
+		),
+		Entry("debian:12 x86_64", "12", "bookworm", "x86_64", "testdata/debian-12-genericcloud-amd64.json",
+			&api.ArtifactDetails{
+				Checksum: "a58d86525d75fd8e139a2302531ce5d2ab75ef0273cfe78f9d53aada4b23efd45f8433b4806fa4570cfe981" +
+					"c8fae26f5e5e855cbd66ba2198862f28125fd2d45",
+				DownloadURL:          "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-amd64.qcow2",
+				ImageArchitecture:    "amd64",
+				AdditionalUniqueTags: []string{"12-20250210-2019"},
+			},
+			&docs.UserData{
+				Username: "debian",
+			},
+			nil,
+			&api.Metadata{
+				Name:        "debian",
+				Version:     "12",
+				Arch:        "x86_64",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "debian",
+				},
+				EnvVariables: nil,
+			},
+		),
+		Entry("debian:12 aarch64", "12", "bookworm", "aarch64", "testdata/debian-12-genericcloud-arm64.json",
+			&api.ArtifactDetails{
+				Checksum: "a17a462acbc3412ef195390fb60dffba2134fef1a276d500ca50a06036c488035657409fcd02f2f70d1e7a9" +
+					"1776ca4249cfbceabeb90e74cb123b9971381c72a",
+				DownloadURL:          "https://cloud.debian.org/images/cloud/bookworm/latest/debian-12-genericcloud-arm64.qcow2",
+				ImageArchitecture:    "arm64",
+				AdditionalUniqueTags: []string{"12-20250210-2019"},
+			},
+			&docs.UserData{
+				Username: "debian",
+			},
+			nil,
+			&api.Metadata{
+				Name:        "debian",
+				Version:     "12",
+				Arch:        "aarch64",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "debian",
+				},
+				EnvVariables: nil,
+			},
+		),
+	)
+})
+
+func TestDebian(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Debian Suite")
+}

--- a/artifacts/debian/testdata/debian-11-genericcloud-amd64.json
+++ b/artifacts/debian/testdata/debian-11-genericcloud-amd64.json
@@ -1,0 +1,1365 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "info": {
+                    "arch": "amd64",
+                    "build_id": "cloud-admin-team-master",
+                    "release": "bullseye",
+                    "release_baseid": "11",
+                    "release_id": "11",
+                    "type": "official",
+                    "vendor": "genericcloud",
+                    "version": "20250303-2040"
+                },
+                "packages": [
+                    {
+                        "name": "adduser",
+                        "version": "3.118+deb11u1"
+                    },
+                    {
+                        "name": "apparmor",
+                        "version": "2.13.6-10"
+                    },
+                    {
+                        "name": "apt",
+                        "version": "2.2.4"
+                    },
+                    {
+                        "name": "apt-listchanges",
+                        "version": "3.24"
+                    },
+                    {
+                        "name": "apt-utils",
+                        "version": "2.2.4"
+                    },
+                    {
+                        "name": "base-files",
+                        "version": "11.1+deb11u11"
+                    },
+                    {
+                        "name": "base-passwd",
+                        "version": "3.5.51"
+                    },
+                    {
+                        "name": "bash",
+                        "version": "5.1-2+deb11u1"
+                    },
+                    {
+                        "name": "bash-completion",
+                        "version": "1:2.11-2"
+                    },
+                    {
+                        "name": "bind9-host",
+                        "version": "1:9.16.50-1~deb11u3"
+                    },
+                    {
+                        "name": "bind9-libs:amd64",
+                        "version": "1:9.16.50-1~deb11u3"
+                    },
+                    {
+                        "name": "bsdextrautils",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "bsdutils",
+                        "version": "1:2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "ca-certificates",
+                        "version": "20210119"
+                    },
+                    {
+                        "name": "chrony",
+                        "version": "4.0-8+deb11u2"
+                    },
+                    {
+                        "name": "cloud-guest-utils",
+                        "version": "0.31-2"
+                    },
+                    {
+                        "name": "cloud-image-utils",
+                        "version": "0.31-2"
+                    },
+                    {
+                        "name": "cloud-init",
+                        "version": "20.4.1-2+deb11u1"
+                    },
+                    {
+                        "name": "cloud-initramfs-growroot",
+                        "version": "0.18.debian8"
+                    },
+                    {
+                        "name": "cloud-utils",
+                        "version": "0.31-2"
+                    },
+                    {
+                        "name": "coreutils",
+                        "version": "8.32-4+b1"
+                    },
+                    {
+                        "name": "cpio",
+                        "version": "2.13+dfsg-7.1~deb11u1"
+                    },
+                    {
+                        "name": "cron",
+                        "version": "3.0pl1-137"
+                    },
+                    {
+                        "name": "curl",
+                        "version": "7.74.0-1.3+deb11u14"
+                    },
+                    {
+                        "name": "dash",
+                        "version": "0.5.11+git20200708+dd9ef66-5"
+                    },
+                    {
+                        "name": "dbus",
+                        "version": "1.12.28-0+deb11u1"
+                    },
+                    {
+                        "name": "debconf",
+                        "version": "1.5.77"
+                    },
+                    {
+                        "name": "debian-archive-keyring",
+                        "version": "2021.1.1+deb11u1"
+                    },
+                    {
+                        "name": "debianutils",
+                        "version": "4.11.2"
+                    },
+                    {
+                        "name": "diffutils",
+                        "version": "1:3.7-5"
+                    },
+                    {
+                        "name": "distro-info-data",
+                        "version": "0.51+deb11u7"
+                    },
+                    {
+                        "name": "dmsetup",
+                        "version": "2:1.02.175-2.1"
+                    },
+                    {
+                        "name": "dpkg",
+                        "version": "1.20.13"
+                    },
+                    {
+                        "name": "e2fsprogs",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "ethtool",
+                        "version": "1:5.9-1"
+                    },
+                    {
+                        "name": "fdisk",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "file",
+                        "version": "1:5.39-3+deb11u1"
+                    },
+                    {
+                        "name": "findutils",
+                        "version": "4.8.0-1"
+                    },
+                    {
+                        "name": "gcc-10-base:amd64",
+                        "version": "10.2.1-6"
+                    },
+                    {
+                        "name": "gcc-9-base:amd64",
+                        "version": "9.3.0-22"
+                    },
+                    {
+                        "name": "gdisk",
+                        "version": "1.0.6-1.1"
+                    },
+                    {
+                        "name": "genisoimage",
+                        "version": "9:1.1.11-3.2"
+                    },
+                    {
+                        "name": "gettext-base",
+                        "version": "0.21-4"
+                    },
+                    {
+                        "name": "gpgv",
+                        "version": "2.2.27-2+deb11u2"
+                    },
+                    {
+                        "name": "grep",
+                        "version": "3.6-1+deb11u1"
+                    },
+                    {
+                        "name": "groff-base",
+                        "version": "1.22.4-6"
+                    },
+                    {
+                        "name": "grub-cloud-amd64",
+                        "version": "0.0.5"
+                    },
+                    {
+                        "name": "grub-common",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "grub-efi-amd64-bin",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "grub-efi-amd64-signed",
+                        "version": "1+2.06+3~deb11u6"
+                    },
+                    {
+                        "name": "grub-pc-bin",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "grub2-common",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "gzip",
+                        "version": "1.10-4+deb11u1"
+                    },
+                    {
+                        "name": "hostname",
+                        "version": "3.23"
+                    },
+                    {
+                        "name": "ifupdown",
+                        "version": "0.8.36"
+                    },
+                    {
+                        "name": "init",
+                        "version": "1.60"
+                    },
+                    {
+                        "name": "init-system-helpers",
+                        "version": "1.60"
+                    },
+                    {
+                        "name": "initramfs-tools",
+                        "version": "0.140"
+                    },
+                    {
+                        "name": "initramfs-tools-core",
+                        "version": "0.140"
+                    },
+                    {
+                        "name": "iproute2",
+                        "version": "5.10.0-4"
+                    },
+                    {
+                        "name": "iptables",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "iputils-ping",
+                        "version": "3:20210202-1"
+                    },
+                    {
+                        "name": "isc-dhcp-client",
+                        "version": "4.4.1-2.3+deb11u2"
+                    },
+                    {
+                        "name": "klibc-utils",
+                        "version": "2.0.8-6.1"
+                    },
+                    {
+                        "name": "kmod",
+                        "version": "28-1"
+                    },
+                    {
+                        "name": "less",
+                        "version": "551-2+deb11u2"
+                    },
+                    {
+                        "name": "libacl1:amd64",
+                        "version": "2.2.53-10"
+                    },
+                    {
+                        "name": "libaio1:amd64",
+                        "version": "0.3.112-9"
+                    },
+                    {
+                        "name": "libapparmor1:amd64",
+                        "version": "2.13.6-10"
+                    },
+                    {
+                        "name": "libapt-pkg6.0:amd64",
+                        "version": "2.2.4"
+                    },
+                    {
+                        "name": "libargon2-1:amd64",
+                        "version": "0~20171227-0.2"
+                    },
+                    {
+                        "name": "libattr1:amd64",
+                        "version": "1:2.4.48-6"
+                    },
+                    {
+                        "name": "libaudit-common",
+                        "version": "1:3.0-2"
+                    },
+                    {
+                        "name": "libaudit1:amd64",
+                        "version": "1:3.0-2"
+                    },
+                    {
+                        "name": "libblkid1:amd64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libbpf0:amd64",
+                        "version": "1:0.3-2"
+                    },
+                    {
+                        "name": "libbrotli1:amd64",
+                        "version": "1.0.9-2+b2"
+                    },
+                    {
+                        "name": "libbsd0:amd64",
+                        "version": "0.11.3-1+deb11u1"
+                    },
+                    {
+                        "name": "libbz2-1.0:amd64",
+                        "version": "1.0.8-4"
+                    },
+                    {
+                        "name": "libc-bin",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "libc-l10n",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "libc6:amd64",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "libcap-ng0:amd64",
+                        "version": "0.7.9-2.2+b1"
+                    },
+                    {
+                        "name": "libcap2:amd64",
+                        "version": "1:2.44-1"
+                    },
+                    {
+                        "name": "libcap2-bin",
+                        "version": "1:2.44-1"
+                    },
+                    {
+                        "name": "libcbor0:amd64",
+                        "version": "0.5.0+dfsg-2"
+                    },
+                    {
+                        "name": "libcom-err2:amd64",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "libcrypt1:amd64",
+                        "version": "1:4.4.18-4"
+                    },
+                    {
+                        "name": "libcryptsetup12:amd64",
+                        "version": "2:2.3.7-1+deb11u1"
+                    },
+                    {
+                        "name": "libcurl3-gnutls:amd64",
+                        "version": "7.74.0-1.3+deb11u14"
+                    },
+                    {
+                        "name": "libcurl4:amd64",
+                        "version": "7.74.0-1.3+deb11u14"
+                    },
+                    {
+                        "name": "libdb5.3:amd64",
+                        "version": "5.3.28+dfsg1-0.8"
+                    },
+                    {
+                        "name": "libdbus-1-3:amd64",
+                        "version": "1.12.28-0+deb11u1"
+                    },
+                    {
+                        "name": "libdebconfclient0:amd64",
+                        "version": "0.260"
+                    },
+                    {
+                        "name": "libdevmapper1.02.1:amd64",
+                        "version": "2:1.02.175-2.1"
+                    },
+                    {
+                        "name": "libdns-export1110",
+                        "version": "1:9.11.19+dfsg-2.1"
+                    },
+                    {
+                        "name": "libedit2:amd64",
+                        "version": "3.1-20191231-2+b1"
+                    },
+                    {
+                        "name": "libefiboot1:amd64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libefivar1:amd64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libelf1:amd64",
+                        "version": "0.183-1"
+                    },
+                    {
+                        "name": "libestr0:amd64",
+                        "version": "0.1.10-2.1+b1"
+                    },
+                    {
+                        "name": "libexpat1:amd64",
+                        "version": "2.2.10-2+deb11u6"
+                    },
+                    {
+                        "name": "libext2fs2:amd64",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "libfastjson4:amd64",
+                        "version": "0.99.9-1"
+                    },
+                    {
+                        "name": "libfdisk1:amd64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libffi7:amd64",
+                        "version": "3.3-6"
+                    },
+                    {
+                        "name": "libfido2-1:amd64",
+                        "version": "1.6.0-2"
+                    },
+                    {
+                        "name": "libfreetype6:amd64",
+                        "version": "2.10.4+dfsg-1+deb11u1"
+                    },
+                    {
+                        "name": "libfstrm0:amd64",
+                        "version": "0.6.0-1+b1"
+                    },
+                    {
+                        "name": "libfuse2:amd64",
+                        "version": "2.9.9-5"
+                    },
+                    {
+                        "name": "libgcc-s1:amd64",
+                        "version": "10.2.1-6"
+                    },
+                    {
+                        "name": "libgcrypt20:amd64",
+                        "version": "1.8.7-6"
+                    },
+                    {
+                        "name": "libgdbm6:amd64",
+                        "version": "1.19-2"
+                    },
+                    {
+                        "name": "libglib2.0-0:amd64",
+                        "version": "2.66.8-1+deb11u5"
+                    },
+                    {
+                        "name": "libgmp10:amd64",
+                        "version": "2:6.2.1+dfsg-1+deb11u1"
+                    },
+                    {
+                        "name": "libgnutls30:amd64",
+                        "version": "3.7.1-5+deb11u7"
+                    },
+                    {
+                        "name": "libgpg-error0:amd64",
+                        "version": "1.38-2"
+                    },
+                    {
+                        "name": "libgpm2:amd64",
+                        "version": "1.20.7-8"
+                    },
+                    {
+                        "name": "libgssapi-krb5-2:amd64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libhogweed6:amd64",
+                        "version": "3.7.3-1"
+                    },
+                    {
+                        "name": "libicu67:amd64",
+                        "version": "67.1-7"
+                    },
+                    {
+                        "name": "libidn2-0:amd64",
+                        "version": "2.3.0-5"
+                    },
+                    {
+                        "name": "libip4tc2:amd64",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "libip6tc2:amd64",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "libisc-export1105:amd64",
+                        "version": "1:9.11.19+dfsg-2.1"
+                    },
+                    {
+                        "name": "libjson-c5:amd64",
+                        "version": "0.15-2+deb11u1"
+                    },
+                    {
+                        "name": "libk5crypto3:amd64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libkeyutils1:amd64",
+                        "version": "1.6.1-2"
+                    },
+                    {
+                        "name": "libklibc:amd64",
+                        "version": "2.0.8-6.1"
+                    },
+                    {
+                        "name": "libkmod2:amd64",
+                        "version": "28-1"
+                    },
+                    {
+                        "name": "libkrb5-3:amd64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libkrb5support0:amd64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libldap-2.4-2:amd64",
+                        "version": "2.4.57+dfsg-3+deb11u1"
+                    },
+                    {
+                        "name": "liblmdb0:amd64",
+                        "version": "0.9.24-1"
+                    },
+                    {
+                        "name": "liblognorm5:amd64",
+                        "version": "2.0.5-1.1"
+                    },
+                    {
+                        "name": "liblz4-1:amd64",
+                        "version": "1.9.3-2"
+                    },
+                    {
+                        "name": "liblzma5:amd64",
+                        "version": "5.2.5-2.1~deb11u1"
+                    },
+                    {
+                        "name": "libmagic-mgc",
+                        "version": "1:5.39-3+deb11u1"
+                    },
+                    {
+                        "name": "libmagic1:amd64",
+                        "version": "1:5.39-3+deb11u1"
+                    },
+                    {
+                        "name": "libmaxminddb0:amd64",
+                        "version": "1.5.2-1"
+                    },
+                    {
+                        "name": "libmd0:amd64",
+                        "version": "1.0.3-3"
+                    },
+                    {
+                        "name": "libmnl0:amd64",
+                        "version": "1.0.4-3"
+                    },
+                    {
+                        "name": "libmount1:amd64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libmpdec3:amd64",
+                        "version": "2.5.1-1"
+                    },
+                    {
+                        "name": "libncurses6:amd64",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "libncursesw6:amd64",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "libnetfilter-conntrack3:amd64",
+                        "version": "1.0.8-3"
+                    },
+                    {
+                        "name": "libnettle8:amd64",
+                        "version": "3.7.3-1"
+                    },
+                    {
+                        "name": "libnewt0.52:amd64",
+                        "version": "0.52.21-4+b3"
+                    },
+                    {
+                        "name": "libnfnetlink0:amd64",
+                        "version": "1.0.1-3+b1"
+                    },
+                    {
+                        "name": "libnftnl11:amd64",
+                        "version": "1.1.9-1"
+                    },
+                    {
+                        "name": "libnghttp2-14:amd64",
+                        "version": "1.43.0-1+deb11u2"
+                    },
+                    {
+                        "name": "libnsl2:amd64",
+                        "version": "1.3.0-2"
+                    },
+                    {
+                        "name": "libp11-kit0:amd64",
+                        "version": "0.23.22-1"
+                    },
+                    {
+                        "name": "libpam-modules:amd64",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpam-modules-bin",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpam-runtime",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpam-systemd:amd64",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "libpam0g:amd64",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpcap0.8:amd64",
+                        "version": "1.10.0-2"
+                    },
+                    {
+                        "name": "libpci3:amd64",
+                        "version": "1:3.7.0-5"
+                    },
+                    {
+                        "name": "libpcre2-8-0:amd64",
+                        "version": "10.36-2+deb11u1"
+                    },
+                    {
+                        "name": "libpcre3:amd64",
+                        "version": "2:8.39-13"
+                    },
+                    {
+                        "name": "libpipeline1:amd64",
+                        "version": "1.5.3-1"
+                    },
+                    {
+                        "name": "libpng16-16:amd64",
+                        "version": "1.6.37-3"
+                    },
+                    {
+                        "name": "libpopt0:amd64",
+                        "version": "1.18-2"
+                    },
+                    {
+                        "name": "libprocps8:amd64",
+                        "version": "2:3.3.17-5"
+                    },
+                    {
+                        "name": "libprotobuf-c1:amd64",
+                        "version": "1.3.3-1+b2"
+                    },
+                    {
+                        "name": "libpsl5:amd64",
+                        "version": "0.21.0-1.2"
+                    },
+                    {
+                        "name": "libpython3-stdlib:amd64",
+                        "version": "3.9.2-3"
+                    },
+                    {
+                        "name": "libpython3.9-minimal:amd64",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "libpython3.9-stdlib:amd64",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "libreadline8:amd64",
+                        "version": "8.1-1"
+                    },
+                    {
+                        "name": "librtmp1:amd64",
+                        "version": "2.4+20151223.gitfa8646d.1-2+b2"
+                    },
+                    {
+                        "name": "libsasl2-2:amd64",
+                        "version": "2.1.27+dfsg-2.1+deb11u1"
+                    },
+                    {
+                        "name": "libsasl2-modules-db:amd64",
+                        "version": "2.1.27+dfsg-2.1+deb11u1"
+                    },
+                    {
+                        "name": "libseccomp2:amd64",
+                        "version": "2.5.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libselinux1:amd64",
+                        "version": "3.1-3"
+                    },
+                    {
+                        "name": "libsemanage-common",
+                        "version": "3.1-1"
+                    },
+                    {
+                        "name": "libsemanage1:amd64",
+                        "version": "3.1-1+b2"
+                    },
+                    {
+                        "name": "libsepol1:amd64",
+                        "version": "3.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libslang2:amd64",
+                        "version": "2.3.2-5"
+                    },
+                    {
+                        "name": "libsmartcols1:amd64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libsqlite3-0:amd64",
+                        "version": "3.34.1-3+deb11u1"
+                    },
+                    {
+                        "name": "libss2:amd64",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "libssh2-1:amd64",
+                        "version": "1.9.0-2+deb11u1"
+                    },
+                    {
+                        "name": "libssl1.1:amd64",
+                        "version": "1.1.1w-0+deb11u2"
+                    },
+                    {
+                        "name": "libstdc++6:amd64",
+                        "version": "10.2.1-6"
+                    },
+                    {
+                        "name": "libsystemd0:amd64",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "libtasn1-6:amd64",
+                        "version": "4.16.0-2+deb11u2"
+                    },
+                    {
+                        "name": "libtinfo6:amd64",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "libtirpc-common",
+                        "version": "1.3.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libtirpc3:amd64",
+                        "version": "1.3.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libuchardet0:amd64",
+                        "version": "0.0.7-1"
+                    },
+                    {
+                        "name": "libudev1:amd64",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "libunistring2:amd64",
+                        "version": "0.9.10-4"
+                    },
+                    {
+                        "name": "liburing1:amd64",
+                        "version": "0.7-3"
+                    },
+                    {
+                        "name": "libutempter0:amd64",
+                        "version": "1.2.1-2"
+                    },
+                    {
+                        "name": "libuuid1:amd64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libuv1:amd64",
+                        "version": "1.40.0-2+deb11u1"
+                    },
+                    {
+                        "name": "libwrap0:amd64",
+                        "version": "7.6.q-31"
+                    },
+                    {
+                        "name": "libxml2:amd64",
+                        "version": "2.9.10+dfsg-6.7+deb11u6"
+                    },
+                    {
+                        "name": "libxtables12:amd64",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "libxxhash0:amd64",
+                        "version": "0.8.0-2"
+                    },
+                    {
+                        "name": "libyaml-0-2:amd64",
+                        "version": "0.2.2-1"
+                    },
+                    {
+                        "name": "libzstd1:amd64",
+                        "version": "1.4.8+dfsg-2.1"
+                    },
+                    {
+                        "name": "linux-base",
+                        "version": "4.6"
+                    },
+                    {
+                        "name": "linux-image-5.10.0-34-cloud-amd64",
+                        "version": "5.10.234-1"
+                    },
+                    {
+                        "name": "linux-image-cloud-amd64",
+                        "version": "5.10.234-1"
+                    },
+                    {
+                        "name": "locales",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "login",
+                        "version": "1:4.8.1-1"
+                    },
+                    {
+                        "name": "logrotate",
+                        "version": "3.18.0-2+deb11u2"
+                    },
+                    {
+                        "name": "logsave",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "lsb-base",
+                        "version": "11.1.0"
+                    },
+                    {
+                        "name": "lsb-release",
+                        "version": "11.1.0"
+                    },
+                    {
+                        "name": "man-db",
+                        "version": "2.9.4-2"
+                    },
+                    {
+                        "name": "manpages",
+                        "version": "5.10-1"
+                    },
+                    {
+                        "name": "mawk",
+                        "version": "1.3.4.20200120-2"
+                    },
+                    {
+                        "name": "media-types",
+                        "version": "4.0.0"
+                    },
+                    {
+                        "name": "mokutil",
+                        "version": "0.6.0-2~deb11u1"
+                    },
+                    {
+                        "name": "mount",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "nano",
+                        "version": "5.4-2+deb11u3"
+                    },
+                    {
+                        "name": "ncurses-base",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "ncurses-bin",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "net-tools",
+                        "version": "1.60+git20181103.0eebece-1+deb11u1"
+                    },
+                    {
+                        "name": "netbase",
+                        "version": "6.3"
+                    },
+                    {
+                        "name": "openssh-client",
+                        "version": "1:8.4p1-5+deb11u4"
+                    },
+                    {
+                        "name": "openssh-server",
+                        "version": "1:8.4p1-5+deb11u4"
+                    },
+                    {
+                        "name": "openssh-sftp-server",
+                        "version": "1:8.4p1-5+deb11u4"
+                    },
+                    {
+                        "name": "openssl",
+                        "version": "1.1.1w-0+deb11u2"
+                    },
+                    {
+                        "name": "passwd",
+                        "version": "1:4.8.1-1"
+                    },
+                    {
+                        "name": "pci.ids",
+                        "version": "0.0~2021.02.08-1"
+                    },
+                    {
+                        "name": "pciutils",
+                        "version": "1:3.7.0-5"
+                    },
+                    {
+                        "name": "perl-base",
+                        "version": "5.32.1-4+deb11u4"
+                    },
+                    {
+                        "name": "procps",
+                        "version": "2:3.3.17-5"
+                    },
+                    {
+                        "name": "psmisc",
+                        "version": "23.4-2"
+                    },
+                    {
+                        "name": "python-apt-common",
+                        "version": "2.2.1"
+                    },
+                    {
+                        "name": "python3",
+                        "version": "3.9.2-3"
+                    },
+                    {
+                        "name": "python3-apt",
+                        "version": "2.2.1"
+                    },
+                    {
+                        "name": "python3-attr",
+                        "version": "20.3.0-1"
+                    },
+                    {
+                        "name": "python3-blinker",
+                        "version": "1.4+dfsg1-0.3"
+                    },
+                    {
+                        "name": "python3-certifi",
+                        "version": "2020.6.20-1"
+                    },
+                    {
+                        "name": "python3-cffi-backend:amd64",
+                        "version": "1.14.5-1"
+                    },
+                    {
+                        "name": "python3-chardet",
+                        "version": "4.0.0-1"
+                    },
+                    {
+                        "name": "python3-configobj",
+                        "version": "5.0.6-4"
+                    },
+                    {
+                        "name": "python3-cryptography",
+                        "version": "3.3.2-1+deb11u1"
+                    },
+                    {
+                        "name": "python3-dbus",
+                        "version": "1.2.16-5"
+                    },
+                    {
+                        "name": "python3-debconf",
+                        "version": "1.5.77"
+                    },
+                    {
+                        "name": "python3-debian",
+                        "version": "0.1.39"
+                    },
+                    {
+                        "name": "python3-debianbts",
+                        "version": "3.1.0"
+                    },
+                    {
+                        "name": "python3-distro-info",
+                        "version": "1.0+deb11u1"
+                    },
+                    {
+                        "name": "python3-distutils",
+                        "version": "3.9.2-1"
+                    },
+                    {
+                        "name": "python3-httplib2",
+                        "version": "0.18.1-3"
+                    },
+                    {
+                        "name": "python3-idna",
+                        "version": "2.10-1+deb11u1"
+                    },
+                    {
+                        "name": "python3-importlib-metadata",
+                        "version": "1.6.0-2"
+                    },
+                    {
+                        "name": "python3-jinja2",
+                        "version": "2.11.3-1+deb11u2"
+                    },
+                    {
+                        "name": "python3-json-pointer",
+                        "version": "2.0-2"
+                    },
+                    {
+                        "name": "python3-jsonpatch",
+                        "version": "1.25-3"
+                    },
+                    {
+                        "name": "python3-jsonschema",
+                        "version": "3.2.0-3"
+                    },
+                    {
+                        "name": "python3-jwt",
+                        "version": "1.7.1-2"
+                    },
+                    {
+                        "name": "python3-lib2to3",
+                        "version": "3.9.2-1"
+                    },
+                    {
+                        "name": "python3-markupsafe",
+                        "version": "1.1.1-1+b3"
+                    },
+                    {
+                        "name": "python3-minimal",
+                        "version": "3.9.2-3"
+                    },
+                    {
+                        "name": "python3-more-itertools",
+                        "version": "4.2.0-3"
+                    },
+                    {
+                        "name": "python3-oauthlib",
+                        "version": "3.1.0-2"
+                    },
+                    {
+                        "name": "python3-pkg-resources",
+                        "version": "52.0.0-4+deb11u1"
+                    },
+                    {
+                        "name": "python3-pycurl",
+                        "version": "7.43.0.6-5"
+                    },
+                    {
+                        "name": "python3-pyrsistent:amd64",
+                        "version": "0.15.5-1+b3"
+                    },
+                    {
+                        "name": "python3-pysimplesoap",
+                        "version": "1.16.2-3"
+                    },
+                    {
+                        "name": "python3-reportbug",
+                        "version": "7.10.3+deb11u2"
+                    },
+                    {
+                        "name": "python3-requests",
+                        "version": "2.25.1+dfsg-2"
+                    },
+                    {
+                        "name": "python3-setuptools",
+                        "version": "52.0.0-4+deb11u1"
+                    },
+                    {
+                        "name": "python3-six",
+                        "version": "1.16.0-2"
+                    },
+                    {
+                        "name": "python3-urllib3",
+                        "version": "1.26.5-1~exp1+deb11u1"
+                    },
+                    {
+                        "name": "python3-yaml",
+                        "version": "5.3.1-5"
+                    },
+                    {
+                        "name": "python3-zipp",
+                        "version": "1.0.0-3"
+                    },
+                    {
+                        "name": "python3.9",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "python3.9-minimal",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "qemu-utils",
+                        "version": "1:5.2+dfsg-11+deb11u3"
+                    },
+                    {
+                        "name": "readline-common",
+                        "version": "8.1-1"
+                    },
+                    {
+                        "name": "reportbug",
+                        "version": "7.10.3+deb11u2"
+                    },
+                    {
+                        "name": "resolvconf",
+                        "version": "1.87"
+                    },
+                    {
+                        "name": "rsyslog",
+                        "version": "8.2102.0-2+deb11u1"
+                    },
+                    {
+                        "name": "runit-helper",
+                        "version": "2.10.3"
+                    },
+                    {
+                        "name": "screen",
+                        "version": "4.8.0-6"
+                    },
+                    {
+                        "name": "sed",
+                        "version": "4.7-1"
+                    },
+                    {
+                        "name": "sensible-utils",
+                        "version": "0.0.14"
+                    },
+                    {
+                        "name": "shim-helpers-amd64-signed",
+                        "version": "1+15.8+1~deb11u1"
+                    },
+                    {
+                        "name": "shim-signed:amd64",
+                        "version": "1.44~1+deb11u1+15.8-1~deb11u1"
+                    },
+                    {
+                        "name": "shim-signed-common",
+                        "version": "1.44~1+deb11u1+15.8-1~deb11u1"
+                    },
+                    {
+                        "name": "shim-unsigned",
+                        "version": "15.8-1~deb11u1"
+                    },
+                    {
+                        "name": "socat",
+                        "version": "1.7.4.1-3"
+                    },
+                    {
+                        "name": "sudo",
+                        "version": "1.9.5p2-3+deb11u1"
+                    },
+                    {
+                        "name": "systemd",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "systemd-sysv",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "sysvinit-utils",
+                        "version": "2.96-7+deb11u1"
+                    },
+                    {
+                        "name": "tar",
+                        "version": "1.34+dfsg-1+deb11u1"
+                    },
+                    {
+                        "name": "tcpdump",
+                        "version": "4.99.0-2+deb11u1"
+                    },
+                    {
+                        "name": "traceroute",
+                        "version": "1:2.1.0-2+deb11u1"
+                    },
+                    {
+                        "name": "tzdata",
+                        "version": "2024b-0+deb11u1"
+                    },
+                    {
+                        "name": "ucf",
+                        "version": "3.0043+deb11u2"
+                    },
+                    {
+                        "name": "udev",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "unattended-upgrades",
+                        "version": "2.8"
+                    },
+                    {
+                        "name": "util-linux",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "uuid-runtime",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "vim",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "vim-common",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "vim-runtime",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "vim-tiny",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "wget",
+                        "version": "1.21-1+deb11u1"
+                    },
+                    {
+                        "name": "whiptail",
+                        "version": "0.52.21-4+b3"
+                    },
+                    {
+                        "name": "xxd",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "xz-utils",
+                        "version": "5.2.5-2.1~deb11u1"
+                    },
+                    {
+                        "name": "zlib1g:amd64",
+                        "version": "1:1.2.11.dfsg-2+deb11u2"
+                    }
+                ]
+            },
+            "kind": "Build",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:vCRK/sDmLnGesY0renGvg7hPoFjKj7R1/ucxxKSYq65TlUBLUf7Kt5wSC/f3uhfSj35Lur8JQCU42KdTN3cVCg"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye"
+                },
+                "uid": "cf5a5c9d-6de3-40db-b7f5-688cb3513b0c"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bullseye/20250303-2040/debian-11-genericcloud-amd64-20250303-2040.tar.xz"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:5miu9BcaBogH2Dsi5wnRyIddwBVoAK0snfCbfNC5JYlJNKWZ5SNmRQvWtXYI1Bi/PTzGasg3o2HLEvAssT44eg"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye",
+                    "upload.cloud.debian.org/image-format": "internal",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "54ceef36-233b-4d28-82e8-366d3509dfb3"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bullseye/20250303-2040/debian-11-genericcloud-amd64-20250303-2040.raw"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:XJ7svoVws0NjyyNTPpkhY+BRI7qn0UOuBGVAWWErPsYTiJVlEHhm6fEUfsnQvCzuLciVyjMhd4mZla6O6+gJhQ"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye",
+                    "upload.cloud.debian.org/image-format": "raw",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "19166878-24b8-4687-b1ce-09fdae791f9c"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bullseye/20250303-2040/debian-11-genericcloud-amd64-20250303-2040.qcow2"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:PAg1bWhg+YcInBS0WVP7HyZtGxtQ3QhnRJJeLtQRO4BOhIqLG0ZhT+vEjN51nxjoJLdr+wJhjtaz0G7RXqmSgw"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye",
+                    "upload.cloud.debian.org/image-format": "qcow2",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "76574768-71e8-46f9-b6bb-83689e7b8c3f"
+            }
+        }
+    ],
+    "kind": "List"
+}

--- a/artifacts/debian/testdata/debian-11-genericcloud-arm64.json
+++ b/artifacts/debian/testdata/debian-11-genericcloud-arm64.json
@@ -1,0 +1,1337 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "info": {
+                    "arch": "arm64",
+                    "build_id": "cloud-admin-team-master",
+                    "release": "bullseye",
+                    "release_baseid": "11",
+                    "release_id": "11",
+                    "type": "official",
+                    "vendor": "genericcloud",
+                    "version": "20250303-2040"
+                },
+                "packages": [
+                    {
+                        "name": "adduser",
+                        "version": "3.118+deb11u1"
+                    },
+                    {
+                        "name": "apparmor",
+                        "version": "2.13.6-10"
+                    },
+                    {
+                        "name": "apt",
+                        "version": "2.2.4"
+                    },
+                    {
+                        "name": "apt-listchanges",
+                        "version": "3.24"
+                    },
+                    {
+                        "name": "apt-utils",
+                        "version": "2.2.4"
+                    },
+                    {
+                        "name": "base-files",
+                        "version": "11.1+deb11u11"
+                    },
+                    {
+                        "name": "base-passwd",
+                        "version": "3.5.51"
+                    },
+                    {
+                        "name": "bash",
+                        "version": "5.1-2+deb11u1"
+                    },
+                    {
+                        "name": "bash-completion",
+                        "version": "1:2.11-2"
+                    },
+                    {
+                        "name": "bind9-host",
+                        "version": "1:9.16.50-1~deb11u3"
+                    },
+                    {
+                        "name": "bind9-libs:arm64",
+                        "version": "1:9.16.50-1~deb11u3"
+                    },
+                    {
+                        "name": "bsdextrautils",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "bsdutils",
+                        "version": "1:2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "ca-certificates",
+                        "version": "20210119"
+                    },
+                    {
+                        "name": "chrony",
+                        "version": "4.0-8+deb11u2"
+                    },
+                    {
+                        "name": "cloud-guest-utils",
+                        "version": "0.31-2"
+                    },
+                    {
+                        "name": "cloud-image-utils",
+                        "version": "0.31-2"
+                    },
+                    {
+                        "name": "cloud-init",
+                        "version": "20.4.1-2+deb11u1"
+                    },
+                    {
+                        "name": "cloud-initramfs-growroot",
+                        "version": "0.18.debian8"
+                    },
+                    {
+                        "name": "cloud-utils",
+                        "version": "0.31-2"
+                    },
+                    {
+                        "name": "coreutils",
+                        "version": "8.32-4"
+                    },
+                    {
+                        "name": "cpio",
+                        "version": "2.13+dfsg-7.1~deb11u1"
+                    },
+                    {
+                        "name": "cron",
+                        "version": "3.0pl1-137"
+                    },
+                    {
+                        "name": "curl",
+                        "version": "7.74.0-1.3+deb11u14"
+                    },
+                    {
+                        "name": "dash",
+                        "version": "0.5.11+git20200708+dd9ef66-5"
+                    },
+                    {
+                        "name": "dbus",
+                        "version": "1.12.28-0+deb11u1"
+                    },
+                    {
+                        "name": "debconf",
+                        "version": "1.5.77"
+                    },
+                    {
+                        "name": "debian-archive-keyring",
+                        "version": "2021.1.1+deb11u1"
+                    },
+                    {
+                        "name": "debianutils",
+                        "version": "4.11.2"
+                    },
+                    {
+                        "name": "diffutils",
+                        "version": "1:3.7-5"
+                    },
+                    {
+                        "name": "distro-info-data",
+                        "version": "0.51+deb11u7"
+                    },
+                    {
+                        "name": "dmsetup",
+                        "version": "2:1.02.175-2.1"
+                    },
+                    {
+                        "name": "dpkg",
+                        "version": "1.20.13"
+                    },
+                    {
+                        "name": "e2fsprogs",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "ethtool",
+                        "version": "1:5.9-1"
+                    },
+                    {
+                        "name": "fdisk",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "file",
+                        "version": "1:5.39-3+deb11u1"
+                    },
+                    {
+                        "name": "findutils",
+                        "version": "4.8.0-1"
+                    },
+                    {
+                        "name": "gcc-10-base:arm64",
+                        "version": "10.2.1-6"
+                    },
+                    {
+                        "name": "gcc-9-base:arm64",
+                        "version": "9.3.0-22"
+                    },
+                    {
+                        "name": "gdisk",
+                        "version": "1.0.6-1.1"
+                    },
+                    {
+                        "name": "genisoimage",
+                        "version": "9:1.1.11-3.2"
+                    },
+                    {
+                        "name": "gettext-base",
+                        "version": "0.21-4"
+                    },
+                    {
+                        "name": "gpgv",
+                        "version": "2.2.27-2+deb11u2"
+                    },
+                    {
+                        "name": "grep",
+                        "version": "3.6-1+deb11u1"
+                    },
+                    {
+                        "name": "groff-base",
+                        "version": "1.22.4-6"
+                    },
+                    {
+                        "name": "grub-common",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "grub-efi-arm64",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "grub-efi-arm64-bin",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "grub2-common",
+                        "version": "2.06-3~deb11u6"
+                    },
+                    {
+                        "name": "gzip",
+                        "version": "1.10-4+deb11u1"
+                    },
+                    {
+                        "name": "hostname",
+                        "version": "3.23"
+                    },
+                    {
+                        "name": "ifupdown",
+                        "version": "0.8.36"
+                    },
+                    {
+                        "name": "init",
+                        "version": "1.60"
+                    },
+                    {
+                        "name": "init-system-helpers",
+                        "version": "1.60"
+                    },
+                    {
+                        "name": "initramfs-tools",
+                        "version": "0.140"
+                    },
+                    {
+                        "name": "initramfs-tools-core",
+                        "version": "0.140"
+                    },
+                    {
+                        "name": "iproute2",
+                        "version": "5.10.0-4"
+                    },
+                    {
+                        "name": "iptables",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "iputils-ping",
+                        "version": "3:20210202-1"
+                    },
+                    {
+                        "name": "isc-dhcp-client",
+                        "version": "4.4.1-2.3+deb11u2"
+                    },
+                    {
+                        "name": "klibc-utils",
+                        "version": "2.0.8-6.1"
+                    },
+                    {
+                        "name": "kmod",
+                        "version": "28-1"
+                    },
+                    {
+                        "name": "less",
+                        "version": "551-2+deb11u2"
+                    },
+                    {
+                        "name": "libacl1:arm64",
+                        "version": "2.2.53-10"
+                    },
+                    {
+                        "name": "libaio1:arm64",
+                        "version": "0.3.112-9"
+                    },
+                    {
+                        "name": "libapparmor1:arm64",
+                        "version": "2.13.6-10"
+                    },
+                    {
+                        "name": "libapt-pkg6.0:arm64",
+                        "version": "2.2.4"
+                    },
+                    {
+                        "name": "libargon2-1:arm64",
+                        "version": "0~20171227-0.2"
+                    },
+                    {
+                        "name": "libattr1:arm64",
+                        "version": "1:2.4.48-6"
+                    },
+                    {
+                        "name": "libaudit-common",
+                        "version": "1:3.0-2"
+                    },
+                    {
+                        "name": "libaudit1:arm64",
+                        "version": "1:3.0-2"
+                    },
+                    {
+                        "name": "libblkid1:arm64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libbpf0:arm64",
+                        "version": "1:0.3-2"
+                    },
+                    {
+                        "name": "libbrotli1:arm64",
+                        "version": "1.0.9-2+b2"
+                    },
+                    {
+                        "name": "libbsd0:arm64",
+                        "version": "0.11.3-1+deb11u1"
+                    },
+                    {
+                        "name": "libbz2-1.0:arm64",
+                        "version": "1.0.8-4"
+                    },
+                    {
+                        "name": "libc-bin",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "libc-l10n",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "libc6:arm64",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "libcap-ng0:arm64",
+                        "version": "0.7.9-2.2+b1"
+                    },
+                    {
+                        "name": "libcap2:arm64",
+                        "version": "1:2.44-1"
+                    },
+                    {
+                        "name": "libcap2-bin",
+                        "version": "1:2.44-1"
+                    },
+                    {
+                        "name": "libcbor0:arm64",
+                        "version": "0.5.0+dfsg-2"
+                    },
+                    {
+                        "name": "libcom-err2:arm64",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "libcrypt1:arm64",
+                        "version": "1:4.4.18-4"
+                    },
+                    {
+                        "name": "libcryptsetup12:arm64",
+                        "version": "2:2.3.7-1+deb11u1"
+                    },
+                    {
+                        "name": "libcurl3-gnutls:arm64",
+                        "version": "7.74.0-1.3+deb11u14"
+                    },
+                    {
+                        "name": "libcurl4:arm64",
+                        "version": "7.74.0-1.3+deb11u14"
+                    },
+                    {
+                        "name": "libdb5.3:arm64",
+                        "version": "5.3.28+dfsg1-0.8"
+                    },
+                    {
+                        "name": "libdbus-1-3:arm64",
+                        "version": "1.12.28-0+deb11u1"
+                    },
+                    {
+                        "name": "libdebconfclient0:arm64",
+                        "version": "0.260"
+                    },
+                    {
+                        "name": "libdevmapper1.02.1:arm64",
+                        "version": "2:1.02.175-2.1"
+                    },
+                    {
+                        "name": "libdns-export1110",
+                        "version": "1:9.11.19+dfsg-2.1"
+                    },
+                    {
+                        "name": "libedit2:arm64",
+                        "version": "3.1-20191231-2+b1"
+                    },
+                    {
+                        "name": "libefiboot1:arm64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libefivar1:arm64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libelf1:arm64",
+                        "version": "0.183-1"
+                    },
+                    {
+                        "name": "libestr0:arm64",
+                        "version": "0.1.10-2.1+b1"
+                    },
+                    {
+                        "name": "libexpat1:arm64",
+                        "version": "2.2.10-2+deb11u6"
+                    },
+                    {
+                        "name": "libext2fs2:arm64",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "libfastjson4:arm64",
+                        "version": "0.99.9-1"
+                    },
+                    {
+                        "name": "libfdisk1:arm64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libffi7:arm64",
+                        "version": "3.3-6"
+                    },
+                    {
+                        "name": "libfido2-1:arm64",
+                        "version": "1.6.0-2"
+                    },
+                    {
+                        "name": "libfreetype6:arm64",
+                        "version": "2.10.4+dfsg-1+deb11u1"
+                    },
+                    {
+                        "name": "libfstrm0:arm64",
+                        "version": "0.6.0-1+b1"
+                    },
+                    {
+                        "name": "libfuse2:arm64",
+                        "version": "2.9.9-5"
+                    },
+                    {
+                        "name": "libgcc-s1:arm64",
+                        "version": "10.2.1-6"
+                    },
+                    {
+                        "name": "libgcrypt20:arm64",
+                        "version": "1.8.7-6"
+                    },
+                    {
+                        "name": "libgdbm6:arm64",
+                        "version": "1.19-2"
+                    },
+                    {
+                        "name": "libglib2.0-0:arm64",
+                        "version": "2.66.8-1+deb11u5"
+                    },
+                    {
+                        "name": "libgmp10:arm64",
+                        "version": "2:6.2.1+dfsg-1+deb11u1"
+                    },
+                    {
+                        "name": "libgnutls30:arm64",
+                        "version": "3.7.1-5+deb11u7"
+                    },
+                    {
+                        "name": "libgpg-error0:arm64",
+                        "version": "1.38-2"
+                    },
+                    {
+                        "name": "libgpm2:arm64",
+                        "version": "1.20.7-8"
+                    },
+                    {
+                        "name": "libgssapi-krb5-2:arm64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libhogweed6:arm64",
+                        "version": "3.7.3-1"
+                    },
+                    {
+                        "name": "libicu67:arm64",
+                        "version": "67.1-7"
+                    },
+                    {
+                        "name": "libidn2-0:arm64",
+                        "version": "2.3.0-5"
+                    },
+                    {
+                        "name": "libip4tc2:arm64",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "libip6tc2:arm64",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "libisc-export1105:arm64",
+                        "version": "1:9.11.19+dfsg-2.1"
+                    },
+                    {
+                        "name": "libjson-c5:arm64",
+                        "version": "0.15-2+deb11u1"
+                    },
+                    {
+                        "name": "libk5crypto3:arm64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libkeyutils1:arm64",
+                        "version": "1.6.1-2"
+                    },
+                    {
+                        "name": "libklibc:arm64",
+                        "version": "2.0.8-6.1"
+                    },
+                    {
+                        "name": "libkmod2:arm64",
+                        "version": "28-1"
+                    },
+                    {
+                        "name": "libkrb5-3:arm64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libkrb5support0:arm64",
+                        "version": "1.18.3-6+deb11u6"
+                    },
+                    {
+                        "name": "libldap-2.4-2:arm64",
+                        "version": "2.4.57+dfsg-3+deb11u1"
+                    },
+                    {
+                        "name": "liblmdb0:arm64",
+                        "version": "0.9.24-1"
+                    },
+                    {
+                        "name": "liblognorm5:arm64",
+                        "version": "2.0.5-1.1"
+                    },
+                    {
+                        "name": "liblz4-1:arm64",
+                        "version": "1.9.3-2"
+                    },
+                    {
+                        "name": "liblzma5:arm64",
+                        "version": "5.2.5-2.1~deb11u1"
+                    },
+                    {
+                        "name": "libmagic-mgc",
+                        "version": "1:5.39-3+deb11u1"
+                    },
+                    {
+                        "name": "libmagic1:arm64",
+                        "version": "1:5.39-3+deb11u1"
+                    },
+                    {
+                        "name": "libmaxminddb0:arm64",
+                        "version": "1.5.2-1"
+                    },
+                    {
+                        "name": "libmd0:arm64",
+                        "version": "1.0.3-3"
+                    },
+                    {
+                        "name": "libmnl0:arm64",
+                        "version": "1.0.4-3"
+                    },
+                    {
+                        "name": "libmount1:arm64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libmpdec3:arm64",
+                        "version": "2.5.1-1"
+                    },
+                    {
+                        "name": "libncurses6:arm64",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "libncursesw6:arm64",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "libnetfilter-conntrack3:arm64",
+                        "version": "1.0.8-3"
+                    },
+                    {
+                        "name": "libnettle8:arm64",
+                        "version": "3.7.3-1"
+                    },
+                    {
+                        "name": "libnewt0.52:arm64",
+                        "version": "0.52.21-4+b3"
+                    },
+                    {
+                        "name": "libnfnetlink0:arm64",
+                        "version": "1.0.1-3+b1"
+                    },
+                    {
+                        "name": "libnftnl11:arm64",
+                        "version": "1.1.9-1"
+                    },
+                    {
+                        "name": "libnghttp2-14:arm64",
+                        "version": "1.43.0-1+deb11u2"
+                    },
+                    {
+                        "name": "libnsl2:arm64",
+                        "version": "1.3.0-2"
+                    },
+                    {
+                        "name": "libp11-kit0:arm64",
+                        "version": "0.23.22-1"
+                    },
+                    {
+                        "name": "libpam-modules:arm64",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpam-modules-bin",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpam-runtime",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpam-systemd:arm64",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "libpam0g:arm64",
+                        "version": "1.4.0-9+deb11u1"
+                    },
+                    {
+                        "name": "libpcap0.8:arm64",
+                        "version": "1.10.0-2"
+                    },
+                    {
+                        "name": "libpci3:arm64",
+                        "version": "1:3.7.0-5"
+                    },
+                    {
+                        "name": "libpcre2-8-0:arm64",
+                        "version": "10.36-2+deb11u1"
+                    },
+                    {
+                        "name": "libpcre3:arm64",
+                        "version": "2:8.39-13"
+                    },
+                    {
+                        "name": "libpipeline1:arm64",
+                        "version": "1.5.3-1"
+                    },
+                    {
+                        "name": "libpng16-16:arm64",
+                        "version": "1.6.37-3"
+                    },
+                    {
+                        "name": "libpopt0:arm64",
+                        "version": "1.18-2"
+                    },
+                    {
+                        "name": "libprocps8:arm64",
+                        "version": "2:3.3.17-5"
+                    },
+                    {
+                        "name": "libprotobuf-c1:arm64",
+                        "version": "1.3.3-1+b2"
+                    },
+                    {
+                        "name": "libpsl5:arm64",
+                        "version": "0.21.0-1.2"
+                    },
+                    {
+                        "name": "libpython3-stdlib:arm64",
+                        "version": "3.9.2-3"
+                    },
+                    {
+                        "name": "libpython3.9-minimal:arm64",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "libpython3.9-stdlib:arm64",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "libreadline8:arm64",
+                        "version": "8.1-1"
+                    },
+                    {
+                        "name": "librtmp1:arm64",
+                        "version": "2.4+20151223.gitfa8646d.1-2+b2"
+                    },
+                    {
+                        "name": "libsasl2-2:arm64",
+                        "version": "2.1.27+dfsg-2.1+deb11u1"
+                    },
+                    {
+                        "name": "libsasl2-modules-db:arm64",
+                        "version": "2.1.27+dfsg-2.1+deb11u1"
+                    },
+                    {
+                        "name": "libseccomp2:arm64",
+                        "version": "2.5.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libselinux1:arm64",
+                        "version": "3.1-3"
+                    },
+                    {
+                        "name": "libsemanage-common",
+                        "version": "3.1-1"
+                    },
+                    {
+                        "name": "libsemanage1:arm64",
+                        "version": "3.1-1+b2"
+                    },
+                    {
+                        "name": "libsepol1:arm64",
+                        "version": "3.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libslang2:arm64",
+                        "version": "2.3.2-5"
+                    },
+                    {
+                        "name": "libsmartcols1:arm64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libsqlite3-0:arm64",
+                        "version": "3.34.1-3+deb11u1"
+                    },
+                    {
+                        "name": "libss2:arm64",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "libssh2-1:arm64",
+                        "version": "1.9.0-2+deb11u1"
+                    },
+                    {
+                        "name": "libssl1.1:arm64",
+                        "version": "1.1.1w-0+deb11u2"
+                    },
+                    {
+                        "name": "libstdc++6:arm64",
+                        "version": "10.2.1-6"
+                    },
+                    {
+                        "name": "libsystemd0:arm64",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "libtasn1-6:arm64",
+                        "version": "4.16.0-2+deb11u2"
+                    },
+                    {
+                        "name": "libtinfo6:arm64",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "libtirpc-common",
+                        "version": "1.3.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libtirpc3:arm64",
+                        "version": "1.3.1-1+deb11u1"
+                    },
+                    {
+                        "name": "libuchardet0:arm64",
+                        "version": "0.0.7-1"
+                    },
+                    {
+                        "name": "libudev1:arm64",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "libunistring2:arm64",
+                        "version": "0.9.10-4"
+                    },
+                    {
+                        "name": "liburing1:arm64",
+                        "version": "0.7-3"
+                    },
+                    {
+                        "name": "libutempter0:arm64",
+                        "version": "1.2.1-2"
+                    },
+                    {
+                        "name": "libuuid1:arm64",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "libuv1:arm64",
+                        "version": "1.40.0-2+deb11u1"
+                    },
+                    {
+                        "name": "libwrap0:arm64",
+                        "version": "7.6.q-31"
+                    },
+                    {
+                        "name": "libxml2:arm64",
+                        "version": "2.9.10+dfsg-6.7+deb11u6"
+                    },
+                    {
+                        "name": "libxtables12:arm64",
+                        "version": "1.8.7-1"
+                    },
+                    {
+                        "name": "libxxhash0:arm64",
+                        "version": "0.8.0-2"
+                    },
+                    {
+                        "name": "libyaml-0-2:arm64",
+                        "version": "0.2.2-1"
+                    },
+                    {
+                        "name": "libzstd1:arm64",
+                        "version": "1.4.8+dfsg-2.1"
+                    },
+                    {
+                        "name": "linux-base",
+                        "version": "4.6"
+                    },
+                    {
+                        "name": "linux-image-5.10.0-34-cloud-arm64",
+                        "version": "5.10.234-1"
+                    },
+                    {
+                        "name": "linux-image-cloud-arm64",
+                        "version": "5.10.234-1"
+                    },
+                    {
+                        "name": "locales",
+                        "version": "2.31-13+deb11u11"
+                    },
+                    {
+                        "name": "login",
+                        "version": "1:4.8.1-1"
+                    },
+                    {
+                        "name": "logrotate",
+                        "version": "3.18.0-2+deb11u2"
+                    },
+                    {
+                        "name": "logsave",
+                        "version": "1.46.2-2+deb11u1"
+                    },
+                    {
+                        "name": "lsb-base",
+                        "version": "11.1.0"
+                    },
+                    {
+                        "name": "lsb-release",
+                        "version": "11.1.0"
+                    },
+                    {
+                        "name": "man-db",
+                        "version": "2.9.4-2"
+                    },
+                    {
+                        "name": "manpages",
+                        "version": "5.10-1"
+                    },
+                    {
+                        "name": "mawk",
+                        "version": "1.3.4.20200120-2"
+                    },
+                    {
+                        "name": "media-types",
+                        "version": "4.0.0"
+                    },
+                    {
+                        "name": "mount",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "nano",
+                        "version": "5.4-2+deb11u3"
+                    },
+                    {
+                        "name": "ncurses-base",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "ncurses-bin",
+                        "version": "6.2+20201114-2+deb11u2"
+                    },
+                    {
+                        "name": "net-tools",
+                        "version": "1.60+git20181103.0eebece-1+deb11u1"
+                    },
+                    {
+                        "name": "netbase",
+                        "version": "6.3"
+                    },
+                    {
+                        "name": "openssh-client",
+                        "version": "1:8.4p1-5+deb11u4"
+                    },
+                    {
+                        "name": "openssh-server",
+                        "version": "1:8.4p1-5+deb11u4"
+                    },
+                    {
+                        "name": "openssh-sftp-server",
+                        "version": "1:8.4p1-5+deb11u4"
+                    },
+                    {
+                        "name": "openssl",
+                        "version": "1.1.1w-0+deb11u2"
+                    },
+                    {
+                        "name": "passwd",
+                        "version": "1:4.8.1-1"
+                    },
+                    {
+                        "name": "pci.ids",
+                        "version": "0.0~2021.02.08-1"
+                    },
+                    {
+                        "name": "pciutils",
+                        "version": "1:3.7.0-5"
+                    },
+                    {
+                        "name": "perl-base",
+                        "version": "5.32.1-4+deb11u4"
+                    },
+                    {
+                        "name": "procps",
+                        "version": "2:3.3.17-5"
+                    },
+                    {
+                        "name": "psmisc",
+                        "version": "23.4-2"
+                    },
+                    {
+                        "name": "python-apt-common",
+                        "version": "2.2.1"
+                    },
+                    {
+                        "name": "python3",
+                        "version": "3.9.2-3"
+                    },
+                    {
+                        "name": "python3-apt",
+                        "version": "2.2.1"
+                    },
+                    {
+                        "name": "python3-attr",
+                        "version": "20.3.0-1"
+                    },
+                    {
+                        "name": "python3-blinker",
+                        "version": "1.4+dfsg1-0.3"
+                    },
+                    {
+                        "name": "python3-certifi",
+                        "version": "2020.6.20-1"
+                    },
+                    {
+                        "name": "python3-cffi-backend:arm64",
+                        "version": "1.14.5-1"
+                    },
+                    {
+                        "name": "python3-chardet",
+                        "version": "4.0.0-1"
+                    },
+                    {
+                        "name": "python3-configobj",
+                        "version": "5.0.6-4"
+                    },
+                    {
+                        "name": "python3-cryptography",
+                        "version": "3.3.2-1+deb11u1"
+                    },
+                    {
+                        "name": "python3-dbus",
+                        "version": "1.2.16-5"
+                    },
+                    {
+                        "name": "python3-debconf",
+                        "version": "1.5.77"
+                    },
+                    {
+                        "name": "python3-debian",
+                        "version": "0.1.39"
+                    },
+                    {
+                        "name": "python3-debianbts",
+                        "version": "3.1.0"
+                    },
+                    {
+                        "name": "python3-distro-info",
+                        "version": "1.0+deb11u1"
+                    },
+                    {
+                        "name": "python3-distutils",
+                        "version": "3.9.2-1"
+                    },
+                    {
+                        "name": "python3-httplib2",
+                        "version": "0.18.1-3"
+                    },
+                    {
+                        "name": "python3-idna",
+                        "version": "2.10-1+deb11u1"
+                    },
+                    {
+                        "name": "python3-importlib-metadata",
+                        "version": "1.6.0-2"
+                    },
+                    {
+                        "name": "python3-jinja2",
+                        "version": "2.11.3-1+deb11u2"
+                    },
+                    {
+                        "name": "python3-json-pointer",
+                        "version": "2.0-2"
+                    },
+                    {
+                        "name": "python3-jsonpatch",
+                        "version": "1.25-3"
+                    },
+                    {
+                        "name": "python3-jsonschema",
+                        "version": "3.2.0-3"
+                    },
+                    {
+                        "name": "python3-jwt",
+                        "version": "1.7.1-2"
+                    },
+                    {
+                        "name": "python3-lib2to3",
+                        "version": "3.9.2-1"
+                    },
+                    {
+                        "name": "python3-markupsafe",
+                        "version": "1.1.1-1+b3"
+                    },
+                    {
+                        "name": "python3-minimal",
+                        "version": "3.9.2-3"
+                    },
+                    {
+                        "name": "python3-more-itertools",
+                        "version": "4.2.0-3"
+                    },
+                    {
+                        "name": "python3-oauthlib",
+                        "version": "3.1.0-2"
+                    },
+                    {
+                        "name": "python3-pkg-resources",
+                        "version": "52.0.0-4+deb11u1"
+                    },
+                    {
+                        "name": "python3-pycurl",
+                        "version": "7.43.0.6-5"
+                    },
+                    {
+                        "name": "python3-pyrsistent:arm64",
+                        "version": "0.15.5-1+b3"
+                    },
+                    {
+                        "name": "python3-pysimplesoap",
+                        "version": "1.16.2-3"
+                    },
+                    {
+                        "name": "python3-reportbug",
+                        "version": "7.10.3+deb11u2"
+                    },
+                    {
+                        "name": "python3-requests",
+                        "version": "2.25.1+dfsg-2"
+                    },
+                    {
+                        "name": "python3-setuptools",
+                        "version": "52.0.0-4+deb11u1"
+                    },
+                    {
+                        "name": "python3-six",
+                        "version": "1.16.0-2"
+                    },
+                    {
+                        "name": "python3-urllib3",
+                        "version": "1.26.5-1~exp1+deb11u1"
+                    },
+                    {
+                        "name": "python3-yaml",
+                        "version": "5.3.1-5"
+                    },
+                    {
+                        "name": "python3-zipp",
+                        "version": "1.0.0-3"
+                    },
+                    {
+                        "name": "python3.9",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "python3.9-minimal",
+                        "version": "3.9.2-1+deb11u2"
+                    },
+                    {
+                        "name": "qemu-utils",
+                        "version": "1:5.2+dfsg-11+deb11u3"
+                    },
+                    {
+                        "name": "readline-common",
+                        "version": "8.1-1"
+                    },
+                    {
+                        "name": "reportbug",
+                        "version": "7.10.3+deb11u2"
+                    },
+                    {
+                        "name": "resolvconf",
+                        "version": "1.87"
+                    },
+                    {
+                        "name": "rsyslog",
+                        "version": "8.2102.0-2+deb11u1"
+                    },
+                    {
+                        "name": "runit-helper",
+                        "version": "2.10.3"
+                    },
+                    {
+                        "name": "screen",
+                        "version": "4.8.0-6"
+                    },
+                    {
+                        "name": "sed",
+                        "version": "4.7-1"
+                    },
+                    {
+                        "name": "sensible-utils",
+                        "version": "0.0.14"
+                    },
+                    {
+                        "name": "socat",
+                        "version": "1.7.4.1-3"
+                    },
+                    {
+                        "name": "sudo",
+                        "version": "1.9.5p2-3+deb11u1"
+                    },
+                    {
+                        "name": "systemd",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "systemd-sysv",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "sysvinit-utils",
+                        "version": "2.96-7+deb11u1"
+                    },
+                    {
+                        "name": "tar",
+                        "version": "1.34+dfsg-1+deb11u1"
+                    },
+                    {
+                        "name": "tcpdump",
+                        "version": "4.99.0-2+deb11u1"
+                    },
+                    {
+                        "name": "traceroute",
+                        "version": "1:2.1.0-2+deb11u1"
+                    },
+                    {
+                        "name": "tzdata",
+                        "version": "2024b-0+deb11u1"
+                    },
+                    {
+                        "name": "ucf",
+                        "version": "3.0043+deb11u2"
+                    },
+                    {
+                        "name": "udev",
+                        "version": "247.3-7+deb11u6"
+                    },
+                    {
+                        "name": "unattended-upgrades",
+                        "version": "2.8"
+                    },
+                    {
+                        "name": "util-linux",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "uuid-runtime",
+                        "version": "2.36.1-8+deb11u2"
+                    },
+                    {
+                        "name": "vim",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "vim-common",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "vim-runtime",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "vim-tiny",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "wget",
+                        "version": "1.21-1+deb11u1"
+                    },
+                    {
+                        "name": "whiptail",
+                        "version": "0.52.21-4+b3"
+                    },
+                    {
+                        "name": "xxd",
+                        "version": "2:8.2.2434-3+deb11u1"
+                    },
+                    {
+                        "name": "xz-utils",
+                        "version": "5.2.5-2.1~deb11u1"
+                    },
+                    {
+                        "name": "zlib1g:arm64",
+                        "version": "1:1.2.11.dfsg-2+deb11u2"
+                    }
+                ]
+            },
+            "kind": "Build",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:ybCghPnAiWCnDkNoNuwH7ESUcYvivQ8O1OldZLrz/8N5jX1/tEO2eAq5I1vnjjQKeuHVebLacuunWYiZ/XUxIQ"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye"
+                },
+                "uid": "170b1f76-6105-4498-86f6-c96815898b7d"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bullseye/20250303-2040/debian-11-genericcloud-arm64-20250303-2040.tar.xz"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:CfqSXq8vI1UOUcTpI8fK2VKQURbgEhZMxe/A7TsO8DkDL/1cW/mM7Dr/RvVdnJG3MpBNPV2VHi6DWdB7gp8Uaw"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye",
+                    "upload.cloud.debian.org/image-format": "internal",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "34c2a781-9c4f-4258-af8a-bb774ed65d7c"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bullseye/20250303-2040/debian-11-genericcloud-arm64-20250303-2040.raw"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:VS+/Uf/vXe0KDhIeDXuC3RaF9miJZn9KyMuS2zIGRRh9cTfHIFLrvkR7ct2DKeaCF1XF/vpeN/5UgECVBOcHPg"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye",
+                    "upload.cloud.debian.org/image-format": "raw",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "f5acdc40-2203-4bfb-a7ab-cdc1abcfc145"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bullseye/20250303-2040/debian-11-genericcloud-arm64-20250303-2040.qcow2"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:waFkXPN85iioc0uyXc4J/NCFiGUwJjXOCuiLLaI7thXaQ9SDmEcJ10PNa2tF1W2I6faADwsxELobCcAbmQNC8w"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250303-2040",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bullseye",
+                    "upload.cloud.debian.org/image-format": "qcow2",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "cbb3fdaf-bdac-4c47-8572-435e38d775aa"
+            }
+        }
+    ],
+    "kind": "List"
+}

--- a/artifacts/debian/testdata/debian-12-genericcloud-amd64.json
+++ b/artifacts/debian/testdata/debian-12-genericcloud-amd64.json
@@ -1,0 +1,1405 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "info": {
+                    "arch": "amd64",
+                    "build_id": "cloud-admin-team-master",
+                    "release": "bookworm",
+                    "release_baseid": "12",
+                    "release_id": "12",
+                    "type": "official",
+                    "vendor": "genericcloud",
+                    "version": "20250210-2019"
+                },
+                "packages": [
+                    {
+                        "name": "adduser",
+                        "version": "3.134"
+                    },
+                    {
+                        "name": "apparmor",
+                        "version": "3.0.8-3"
+                    },
+                    {
+                        "name": "apt",
+                        "version": "2.6.1"
+                    },
+                    {
+                        "name": "apt-listchanges",
+                        "version": "3.24"
+                    },
+                    {
+                        "name": "apt-utils",
+                        "version": "2.6.1"
+                    },
+                    {
+                        "name": "base-files",
+                        "version": "12.4+deb12u9"
+                    },
+                    {
+                        "name": "base-passwd",
+                        "version": "3.6.1"
+                    },
+                    {
+                        "name": "bash",
+                        "version": "5.2.15-2+b7"
+                    },
+                    {
+                        "name": "bash-completion",
+                        "version": "1:2.11-6"
+                    },
+                    {
+                        "name": "bind9-host",
+                        "version": "1:9.18.33-1~deb12u2"
+                    },
+                    {
+                        "name": "bind9-libs:amd64",
+                        "version": "1:9.18.33-1~deb12u2"
+                    },
+                    {
+                        "name": "bsdextrautils",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "bsdutils",
+                        "version": "1:2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "ca-certificates",
+                        "version": "20230311"
+                    },
+                    {
+                        "name": "cloud-guest-utils",
+                        "version": "0.33-1"
+                    },
+                    {
+                        "name": "cloud-image-utils",
+                        "version": "0.33-1"
+                    },
+                    {
+                        "name": "cloud-init",
+                        "version": "22.4.2-1+deb12u2"
+                    },
+                    {
+                        "name": "cloud-initramfs-growroot",
+                        "version": "0.18.debian13+deb12u1"
+                    },
+                    {
+                        "name": "cloud-utils",
+                        "version": "0.33-1"
+                    },
+                    {
+                        "name": "coreutils",
+                        "version": "9.1-1"
+                    },
+                    {
+                        "name": "cpio",
+                        "version": "2.13+dfsg-7.1"
+                    },
+                    {
+                        "name": "curl",
+                        "version": "7.88.1-10+deb12u8"
+                    },
+                    {
+                        "name": "dash",
+                        "version": "0.5.12-2"
+                    },
+                    {
+                        "name": "dbus",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-bin",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-daemon",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-session-bus-common",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-system-bus-common",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "debconf",
+                        "version": "1.5.82"
+                    },
+                    {
+                        "name": "debian-archive-keyring",
+                        "version": "2023.3+deb12u1"
+                    },
+                    {
+                        "name": "debianutils",
+                        "version": "5.7-0.5~deb12u1"
+                    },
+                    {
+                        "name": "diffutils",
+                        "version": "1:3.8-4"
+                    },
+                    {
+                        "name": "distro-info-data",
+                        "version": "0.58+deb12u3"
+                    },
+                    {
+                        "name": "dmsetup",
+                        "version": "2:1.02.185-2"
+                    },
+                    {
+                        "name": "dpkg",
+                        "version": "1.21.22"
+                    },
+                    {
+                        "name": "e2fsprogs",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "eject",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "ethtool",
+                        "version": "1:6.1-1"
+                    },
+                    {
+                        "name": "fdisk",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "file",
+                        "version": "1:5.44-3"
+                    },
+                    {
+                        "name": "findutils",
+                        "version": "4.9.0-4"
+                    },
+                    {
+                        "name": "gcc-12-base:amd64",
+                        "version": "12.2.0-14"
+                    },
+                    {
+                        "name": "gdisk",
+                        "version": "1.0.9-2.1"
+                    },
+                    {
+                        "name": "genisoimage",
+                        "version": "9:1.1.11-3.4"
+                    },
+                    {
+                        "name": "gettext-base",
+                        "version": "0.21-12"
+                    },
+                    {
+                        "name": "gpgv",
+                        "version": "2.2.40-1.1"
+                    },
+                    {
+                        "name": "grep",
+                        "version": "3.8-5"
+                    },
+                    {
+                        "name": "groff-base",
+                        "version": "1.22.4-10"
+                    },
+                    {
+                        "name": "grub-cloud-amd64",
+                        "version": "0.0.5"
+                    },
+                    {
+                        "name": "grub-common",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "grub-efi-amd64-bin",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "grub-efi-amd64-signed",
+                        "version": "1+2.06+13+deb12u1"
+                    },
+                    {
+                        "name": "grub-pc-bin",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "grub2-common",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "gzip",
+                        "version": "1.12-1"
+                    },
+                    {
+                        "name": "hostname",
+                        "version": "3.23+nmu1"
+                    },
+                    {
+                        "name": "init",
+                        "version": "1.65.2"
+                    },
+                    {
+                        "name": "init-system-helpers",
+                        "version": "1.65.2"
+                    },
+                    {
+                        "name": "initramfs-tools",
+                        "version": "0.142+deb12u1"
+                    },
+                    {
+                        "name": "initramfs-tools-core",
+                        "version": "0.142+deb12u1"
+                    },
+                    {
+                        "name": "iproute2",
+                        "version": "6.1.0-3"
+                    },
+                    {
+                        "name": "iptables",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "iputils-ping",
+                        "version": "3:20221126-1+deb12u1"
+                    },
+                    {
+                        "name": "isc-dhcp-client",
+                        "version": "4.4.3-P1-2"
+                    },
+                    {
+                        "name": "klibc-utils",
+                        "version": "2.0.12-1"
+                    },
+                    {
+                        "name": "kmod",
+                        "version": "30+20221128-1"
+                    },
+                    {
+                        "name": "less",
+                        "version": "590-2.1~deb12u2"
+                    },
+                    {
+                        "name": "libacl1:amd64",
+                        "version": "2.3.1-3"
+                    },
+                    {
+                        "name": "libaio1:amd64",
+                        "version": "0.3.113-4"
+                    },
+                    {
+                        "name": "libapparmor1:amd64",
+                        "version": "3.0.8-3"
+                    },
+                    {
+                        "name": "libapt-pkg6.0:amd64",
+                        "version": "2.6.1"
+                    },
+                    {
+                        "name": "libargon2-1:amd64",
+                        "version": "0~20171227-0.3+deb12u1"
+                    },
+                    {
+                        "name": "libattr1:amd64",
+                        "version": "1:2.5.1-4"
+                    },
+                    {
+                        "name": "libaudit-common",
+                        "version": "1:3.0.9-1"
+                    },
+                    {
+                        "name": "libaudit1:amd64",
+                        "version": "1:3.0.9-1"
+                    },
+                    {
+                        "name": "libblkid1:amd64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libbpf1:amd64",
+                        "version": "1:1.1.0-1"
+                    },
+                    {
+                        "name": "libbrotli1:amd64",
+                        "version": "1.0.9-2+b6"
+                    },
+                    {
+                        "name": "libbsd0:amd64",
+                        "version": "0.11.7-2"
+                    },
+                    {
+                        "name": "libbz2-1.0:amd64",
+                        "version": "1.0.8-5+b1"
+                    },
+                    {
+                        "name": "libc-bin",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "libc-l10n",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "libc6:amd64",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "libcap-ng0:amd64",
+                        "version": "0.8.3-1+b3"
+                    },
+                    {
+                        "name": "libcap2:amd64",
+                        "version": "1:2.66-4"
+                    },
+                    {
+                        "name": "libcap2-bin",
+                        "version": "1:2.66-4"
+                    },
+                    {
+                        "name": "libcbor0.8:amd64",
+                        "version": "0.8.0-2+b1"
+                    },
+                    {
+                        "name": "libcom-err2:amd64",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "libcrypt1:amd64",
+                        "version": "1:4.4.33-2"
+                    },
+                    {
+                        "name": "libcryptsetup12:amd64",
+                        "version": "2:2.6.1-4~deb12u2"
+                    },
+                    {
+                        "name": "libcurl3-gnutls:amd64",
+                        "version": "7.88.1-10+deb12u8"
+                    },
+                    {
+                        "name": "libcurl4:amd64",
+                        "version": "7.88.1-10+deb12u8"
+                    },
+                    {
+                        "name": "libdb5.3:amd64",
+                        "version": "5.3.28+dfsg2-1"
+                    },
+                    {
+                        "name": "libdbus-1-3:amd64",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "libdebconfclient0:amd64",
+                        "version": "0.270"
+                    },
+                    {
+                        "name": "libdevmapper1.02.1:amd64",
+                        "version": "2:1.02.185-2"
+                    },
+                    {
+                        "name": "libduktape207:amd64",
+                        "version": "2.7.0-2"
+                    },
+                    {
+                        "name": "libedit2:amd64",
+                        "version": "3.1-20221030-2"
+                    },
+                    {
+                        "name": "libefiboot1:amd64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libefivar1:amd64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libelf1:amd64",
+                        "version": "0.188-2.1"
+                    },
+                    {
+                        "name": "libexpat1:amd64",
+                        "version": "2.5.0-1+deb12u1"
+                    },
+                    {
+                        "name": "libext2fs2:amd64",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "libfdisk1:amd64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libffi8:amd64",
+                        "version": "3.4.4-1"
+                    },
+                    {
+                        "name": "libfido2-1:amd64",
+                        "version": "1.12.0-2+b1"
+                    },
+                    {
+                        "name": "libfreetype6:amd64",
+                        "version": "2.12.1+dfsg-5+deb12u3"
+                    },
+                    {
+                        "name": "libfstrm0:amd64",
+                        "version": "0.6.1-1"
+                    },
+                    {
+                        "name": "libfuse2:amd64",
+                        "version": "2.9.9-6+b1"
+                    },
+                    {
+                        "name": "libfuse3-3:amd64",
+                        "version": "3.14.0-4"
+                    },
+                    {
+                        "name": "libgcc-s1:amd64",
+                        "version": "12.2.0-14"
+                    },
+                    {
+                        "name": "libgcrypt20:amd64",
+                        "version": "1.10.1-3"
+                    },
+                    {
+                        "name": "libgdbm6:amd64",
+                        "version": "1.23-3"
+                    },
+                    {
+                        "name": "libglib2.0-0:amd64",
+                        "version": "2.74.6-2+deb12u5"
+                    },
+                    {
+                        "name": "libgmp10:amd64",
+                        "version": "2:6.2.1+dfsg1-1.1"
+                    },
+                    {
+                        "name": "libgnutls30:amd64",
+                        "version": "3.7.9-2+deb12u3"
+                    },
+                    {
+                        "name": "libgpg-error0:amd64",
+                        "version": "1.46-1"
+                    },
+                    {
+                        "name": "libgpm2:amd64",
+                        "version": "1.20.7-10+b1"
+                    },
+                    {
+                        "name": "libgssapi-krb5-2:amd64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libhogweed6:amd64",
+                        "version": "3.8.1-2"
+                    },
+                    {
+                        "name": "libicu72:amd64",
+                        "version": "72.1-3"
+                    },
+                    {
+                        "name": "libidn2-0:amd64",
+                        "version": "2.3.3-1+b1"
+                    },
+                    {
+                        "name": "libip4tc2:amd64",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "libip6tc2:amd64",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "libjemalloc2:amd64",
+                        "version": "5.3.0-1"
+                    },
+                    {
+                        "name": "libjson-c5:amd64",
+                        "version": "0.16-2"
+                    },
+                    {
+                        "name": "libk5crypto3:amd64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libkeyutils1:amd64",
+                        "version": "1.6.3-2"
+                    },
+                    {
+                        "name": "libklibc:amd64",
+                        "version": "2.0.12-1"
+                    },
+                    {
+                        "name": "libkmod2:amd64",
+                        "version": "30+20221128-1"
+                    },
+                    {
+                        "name": "libkrb5-3:amd64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libkrb5support0:amd64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libldap-2.5-0:amd64",
+                        "version": "2.5.13+dfsg-5"
+                    },
+                    {
+                        "name": "liblmdb0:amd64",
+                        "version": "0.9.24-1"
+                    },
+                    {
+                        "name": "liblz4-1:amd64",
+                        "version": "1.9.4-1"
+                    },
+                    {
+                        "name": "liblzma5:amd64",
+                        "version": "5.4.1-0.2"
+                    },
+                    {
+                        "name": "libmagic-mgc",
+                        "version": "1:5.44-3"
+                    },
+                    {
+                        "name": "libmagic1:amd64",
+                        "version": "1:5.44-3"
+                    },
+                    {
+                        "name": "libmaxminddb0:amd64",
+                        "version": "1.7.1-1"
+                    },
+                    {
+                        "name": "libmd0:amd64",
+                        "version": "1.0.4-2"
+                    },
+                    {
+                        "name": "libmnl0:amd64",
+                        "version": "1.0.4-3"
+                    },
+                    {
+                        "name": "libmount1:amd64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libncursesw6:amd64",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "libnetfilter-conntrack3:amd64",
+                        "version": "1.0.9-3"
+                    },
+                    {
+                        "name": "libnetplan0:amd64",
+                        "version": "0.106-2+deb12u1"
+                    },
+                    {
+                        "name": "libnettle8:amd64",
+                        "version": "3.8.1-2"
+                    },
+                    {
+                        "name": "libnewt0.52:amd64",
+                        "version": "0.52.23-1+b1"
+                    },
+                    {
+                        "name": "libnfnetlink0:amd64",
+                        "version": "1.0.2-2"
+                    },
+                    {
+                        "name": "libnftnl11:amd64",
+                        "version": "1.2.4-2"
+                    },
+                    {
+                        "name": "libnghttp2-14:amd64",
+                        "version": "1.52.0-1+deb12u2"
+                    },
+                    {
+                        "name": "libnsl2:amd64",
+                        "version": "1.3.0-2"
+                    },
+                    {
+                        "name": "libnss-myhostname:amd64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libnuma1:amd64",
+                        "version": "2.0.16-1"
+                    },
+                    {
+                        "name": "libp11-kit0:amd64",
+                        "version": "0.24.1-2"
+                    },
+                    {
+                        "name": "libpam-modules:amd64",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpam-modules-bin",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpam-runtime",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpam-systemd:amd64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libpam0g:amd64",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpcap0.8:amd64",
+                        "version": "1.10.3-1"
+                    },
+                    {
+                        "name": "libpci3:amd64",
+                        "version": "1:3.9.0-4"
+                    },
+                    {
+                        "name": "libpcre2-8-0:amd64",
+                        "version": "10.42-1"
+                    },
+                    {
+                        "name": "libpipeline1:amd64",
+                        "version": "1.5.7-1"
+                    },
+                    {
+                        "name": "libpng16-16:amd64",
+                        "version": "1.6.39-2"
+                    },
+                    {
+                        "name": "libpolkit-agent-1-0:amd64",
+                        "version": "122-3"
+                    },
+                    {
+                        "name": "libpolkit-gobject-1-0:amd64",
+                        "version": "122-3"
+                    },
+                    {
+                        "name": "libpopt0:amd64",
+                        "version": "1.19+dfsg-1"
+                    },
+                    {
+                        "name": "libproc2-0:amd64",
+                        "version": "2:4.0.2-3"
+                    },
+                    {
+                        "name": "libprotobuf-c1:amd64",
+                        "version": "1.4.1-1+b1"
+                    },
+                    {
+                        "name": "libpsl5:amd64",
+                        "version": "0.21.2-1"
+                    },
+                    {
+                        "name": "libpython3-stdlib:amd64",
+                        "version": "3.11.2-1+b1"
+                    },
+                    {
+                        "name": "libpython3.11-minimal:amd64",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "libpython3.11-stdlib:amd64",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "libreadline8:amd64",
+                        "version": "8.2-1.3"
+                    },
+                    {
+                        "name": "librtmp1:amd64",
+                        "version": "2.4+20151223.gitfa8646d.1-2+b2"
+                    },
+                    {
+                        "name": "libsasl2-2:amd64",
+                        "version": "2.1.28+dfsg-10"
+                    },
+                    {
+                        "name": "libsasl2-modules-db:amd64",
+                        "version": "2.1.28+dfsg-10"
+                    },
+                    {
+                        "name": "libseccomp2:amd64",
+                        "version": "2.5.4-1+deb12u1"
+                    },
+                    {
+                        "name": "libselinux1:amd64",
+                        "version": "3.4-1+b6"
+                    },
+                    {
+                        "name": "libsemanage-common",
+                        "version": "3.4-1"
+                    },
+                    {
+                        "name": "libsemanage2:amd64",
+                        "version": "3.4-1+b5"
+                    },
+                    {
+                        "name": "libsepol2:amd64",
+                        "version": "3.4-2.1"
+                    },
+                    {
+                        "name": "libslang2:amd64",
+                        "version": "2.3.3-3"
+                    },
+                    {
+                        "name": "libsmartcols1:amd64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libsodium23:amd64",
+                        "version": "1.0.18-1"
+                    },
+                    {
+                        "name": "libsqlite3-0:amd64",
+                        "version": "3.40.1-2+deb12u1"
+                    },
+                    {
+                        "name": "libss2:amd64",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "libssh2-1:amd64",
+                        "version": "1.10.0-3+b1"
+                    },
+                    {
+                        "name": "libssl3:amd64",
+                        "version": "3.0.15-1~deb12u1"
+                    },
+                    {
+                        "name": "libstdc++6:amd64",
+                        "version": "12.2.0-14"
+                    },
+                    {
+                        "name": "libsystemd-shared:amd64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libsystemd0:amd64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libtasn1-6:amd64",
+                        "version": "4.19.0-2"
+                    },
+                    {
+                        "name": "libtinfo6:amd64",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "libtirpc-common",
+                        "version": "1.3.3+ds-1"
+                    },
+                    {
+                        "name": "libtirpc3:amd64",
+                        "version": "1.3.3+ds-1"
+                    },
+                    {
+                        "name": "libuchardet0:amd64",
+                        "version": "0.0.7-1"
+                    },
+                    {
+                        "name": "libudev1:amd64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libunistring2:amd64",
+                        "version": "1.0-2"
+                    },
+                    {
+                        "name": "liburing2:amd64",
+                        "version": "2.3-3"
+                    },
+                    {
+                        "name": "libutempter0:amd64",
+                        "version": "1.2.1-3"
+                    },
+                    {
+                        "name": "libuuid1:amd64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libuv1:amd64",
+                        "version": "1.44.2-1+deb12u1"
+                    },
+                    {
+                        "name": "libwrap0:amd64",
+                        "version": "7.6.q-32"
+                    },
+                    {
+                        "name": "libxml2:amd64",
+                        "version": "2.9.14+dfsg-1.3~deb12u1"
+                    },
+                    {
+                        "name": "libxtables12:amd64",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "libxxhash0:amd64",
+                        "version": "0.8.1-1"
+                    },
+                    {
+                        "name": "libyaml-0-2:amd64",
+                        "version": "0.2.5-1"
+                    },
+                    {
+                        "name": "libzstd1:amd64",
+                        "version": "1.5.4+dfsg2-5"
+                    },
+                    {
+                        "name": "linux-base",
+                        "version": "4.9"
+                    },
+                    {
+                        "name": "linux-image-6.1.0-31-cloud-amd64",
+                        "version": "6.1.128-1"
+                    },
+                    {
+                        "name": "linux-image-cloud-amd64",
+                        "version": "6.1.128-1"
+                    },
+                    {
+                        "name": "locales",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "login",
+                        "version": "1:4.13+dfsg1-1+b1"
+                    },
+                    {
+                        "name": "logsave",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "lsb-release",
+                        "version": "12.0-1"
+                    },
+                    {
+                        "name": "man-db",
+                        "version": "2.11.2-2"
+                    },
+                    {
+                        "name": "manpages",
+                        "version": "6.03-2"
+                    },
+                    {
+                        "name": "mawk",
+                        "version": "1.3.4.20200120-3.1"
+                    },
+                    {
+                        "name": "media-types",
+                        "version": "10.0.0"
+                    },
+                    {
+                        "name": "mokutil",
+                        "version": "0.6.0-2"
+                    },
+                    {
+                        "name": "mount",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "nano",
+                        "version": "7.2-1+deb12u1"
+                    },
+                    {
+                        "name": "ncurses-base",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "ncurses-bin",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "netbase",
+                        "version": "6.4"
+                    },
+                    {
+                        "name": "netplan.io",
+                        "version": "0.106-2+deb12u1"
+                    },
+                    {
+                        "name": "openssh-client",
+                        "version": "1:9.2p1-2+deb12u4"
+                    },
+                    {
+                        "name": "openssh-server",
+                        "version": "1:9.2p1-2+deb12u4"
+                    },
+                    {
+                        "name": "openssh-sftp-server",
+                        "version": "1:9.2p1-2+deb12u4"
+                    },
+                    {
+                        "name": "openssl",
+                        "version": "3.0.15-1~deb12u1"
+                    },
+                    {
+                        "name": "passwd",
+                        "version": "1:4.13+dfsg1-1+b1"
+                    },
+                    {
+                        "name": "pci.ids",
+                        "version": "0.0~2023.04.11-1"
+                    },
+                    {
+                        "name": "pciutils",
+                        "version": "1:3.9.0-4"
+                    },
+                    {
+                        "name": "perl-base",
+                        "version": "5.36.0-7+deb12u1"
+                    },
+                    {
+                        "name": "polkitd",
+                        "version": "122-3"
+                    },
+                    {
+                        "name": "procps",
+                        "version": "2:4.0.2-3"
+                    },
+                    {
+                        "name": "psmisc",
+                        "version": "23.6-1"
+                    },
+                    {
+                        "name": "python-apt-common",
+                        "version": "2.6.0"
+                    },
+                    {
+                        "name": "python3",
+                        "version": "3.11.2-1+b1"
+                    },
+                    {
+                        "name": "python3-apt",
+                        "version": "2.6.0"
+                    },
+                    {
+                        "name": "python3-attr",
+                        "version": "22.2.0-1"
+                    },
+                    {
+                        "name": "python3-blinker",
+                        "version": "1.5-1"
+                    },
+                    {
+                        "name": "python3-certifi",
+                        "version": "2022.9.24-1"
+                    },
+                    {
+                        "name": "python3-cffi-backend:amd64",
+                        "version": "1.15.1-5+b1"
+                    },
+                    {
+                        "name": "python3-chardet",
+                        "version": "5.1.0+dfsg-2"
+                    },
+                    {
+                        "name": "python3-charset-normalizer",
+                        "version": "3.0.1-2"
+                    },
+                    {
+                        "name": "python3-configobj",
+                        "version": "5.0.8-1"
+                    },
+                    {
+                        "name": "python3-cryptography",
+                        "version": "38.0.4-3+deb12u1"
+                    },
+                    {
+                        "name": "python3-dbus",
+                        "version": "1.3.2-4+b1"
+                    },
+                    {
+                        "name": "python3-debconf",
+                        "version": "1.5.82"
+                    },
+                    {
+                        "name": "python3-debian",
+                        "version": "0.1.49"
+                    },
+                    {
+                        "name": "python3-debianbts",
+                        "version": "4.0.1"
+                    },
+                    {
+                        "name": "python3-distro",
+                        "version": "1.8.0-1"
+                    },
+                    {
+                        "name": "python3-distro-info",
+                        "version": "1.5+deb12u1"
+                    },
+                    {
+                        "name": "python3-httplib2",
+                        "version": "0.20.4-3"
+                    },
+                    {
+                        "name": "python3-idna",
+                        "version": "3.3-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-jinja2",
+                        "version": "3.1.2-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-json-pointer",
+                        "version": "2.3-2"
+                    },
+                    {
+                        "name": "python3-jsonpatch",
+                        "version": "1.32-2"
+                    },
+                    {
+                        "name": "python3-jsonschema",
+                        "version": "4.10.3-1"
+                    },
+                    {
+                        "name": "python3-jwt",
+                        "version": "2.6.0-1"
+                    },
+                    {
+                        "name": "python3-markdown-it",
+                        "version": "2.1.0-5"
+                    },
+                    {
+                        "name": "python3-markupsafe",
+                        "version": "2.1.2-1+b1"
+                    },
+                    {
+                        "name": "python3-mdurl",
+                        "version": "0.1.2-1"
+                    },
+                    {
+                        "name": "python3-minimal",
+                        "version": "3.11.2-1+b1"
+                    },
+                    {
+                        "name": "python3-netifaces:amd64",
+                        "version": "0.11.0-2+b1"
+                    },
+                    {
+                        "name": "python3-oauthlib",
+                        "version": "3.2.2-1"
+                    },
+                    {
+                        "name": "python3-pkg-resources",
+                        "version": "66.1.1-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-pycurl",
+                        "version": "7.45.2-3"
+                    },
+                    {
+                        "name": "python3-pygments",
+                        "version": "2.14.0+dfsg-1"
+                    },
+                    {
+                        "name": "python3-pyparsing",
+                        "version": "3.0.9-1"
+                    },
+                    {
+                        "name": "python3-pyrsistent:amd64",
+                        "version": "0.18.1-1+b3"
+                    },
+                    {
+                        "name": "python3-pysimplesoap",
+                        "version": "1.16.2-5"
+                    },
+                    {
+                        "name": "python3-reportbug",
+                        "version": "12.0.0"
+                    },
+                    {
+                        "name": "python3-requests",
+                        "version": "2.28.1+dfsg-1"
+                    },
+                    {
+                        "name": "python3-rich",
+                        "version": "13.3.1-1"
+                    },
+                    {
+                        "name": "python3-serial",
+                        "version": "3.5-1.1"
+                    },
+                    {
+                        "name": "python3-six",
+                        "version": "1.16.0-4"
+                    },
+                    {
+                        "name": "python3-urllib3",
+                        "version": "1.26.12-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-yaml",
+                        "version": "6.0-3+b2"
+                    },
+                    {
+                        "name": "python3.11",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "python3.11-minimal",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "qemu-utils",
+                        "version": "1:7.2+dfsg-7+deb12u12"
+                    },
+                    {
+                        "name": "readline-common",
+                        "version": "8.2-1.3"
+                    },
+                    {
+                        "name": "reportbug",
+                        "version": "12.0.0"
+                    },
+                    {
+                        "name": "runit-helper",
+                        "version": "2.15.2"
+                    },
+                    {
+                        "name": "screen",
+                        "version": "4.9.0-4"
+                    },
+                    {
+                        "name": "sed",
+                        "version": "4.9-1"
+                    },
+                    {
+                        "name": "sensible-utils",
+                        "version": "0.0.17+nmu1"
+                    },
+                    {
+                        "name": "sgml-base",
+                        "version": "1.31"
+                    },
+                    {
+                        "name": "shim-helpers-amd64-signed",
+                        "version": "1+15.8+1~deb12u1"
+                    },
+                    {
+                        "name": "shim-signed:amd64",
+                        "version": "1.44~1+deb12u1+15.8-1~deb12u1"
+                    },
+                    {
+                        "name": "shim-signed-common",
+                        "version": "1.44~1+deb12u1+15.8-1~deb12u1"
+                    },
+                    {
+                        "name": "shim-unsigned:amd64",
+                        "version": "15.8-1~deb12u1"
+                    },
+                    {
+                        "name": "socat",
+                        "version": "1.7.4.4-2"
+                    },
+                    {
+                        "name": "ssh-import-id",
+                        "version": "5.10-1"
+                    },
+                    {
+                        "name": "sudo",
+                        "version": "1.9.13p3-1+deb12u1"
+                    },
+                    {
+                        "name": "systemd",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "systemd-resolved",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "systemd-sysv",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "systemd-timesyncd",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "sysvinit-utils",
+                        "version": "3.06-4"
+                    },
+                    {
+                        "name": "tar",
+                        "version": "1.34+dfsg-1.2+deb12u1"
+                    },
+                    {
+                        "name": "tcpdump",
+                        "version": "4.99.3-1"
+                    },
+                    {
+                        "name": "traceroute",
+                        "version": "1:2.1.2-1"
+                    },
+                    {
+                        "name": "tzdata",
+                        "version": "2024b-0+deb12u1"
+                    },
+                    {
+                        "name": "ucf",
+                        "version": "3.0043+nmu1+deb12u1"
+                    },
+                    {
+                        "name": "udev",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "unattended-upgrades",
+                        "version": "2.9.1+nmu3"
+                    },
+                    {
+                        "name": "usr-is-merged",
+                        "version": "37~deb12u1"
+                    },
+                    {
+                        "name": "util-linux",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "util-linux-extra",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "uuid-runtime",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "vim",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "vim-common",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "vim-runtime",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "vim-tiny",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "wget",
+                        "version": "1.21.3-1+b2"
+                    },
+                    {
+                        "name": "whiptail",
+                        "version": "0.52.23-1+b1"
+                    },
+                    {
+                        "name": "xml-core",
+                        "version": "0.18+nmu1"
+                    },
+                    {
+                        "name": "xz-utils",
+                        "version": "5.4.1-0.2"
+                    },
+                    {
+                        "name": "zlib1g:amd64",
+                        "version": "1:1.2.13.dfsg-1"
+                    },
+                    {
+                        "name": "zstd",
+                        "version": "1.5.4+dfsg2-5"
+                    }
+                ]
+            },
+            "kind": "Build",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:oDnog75S1bOI8YmYKmYBC6DTrjRj+3ucikDmYEWGrf69J2Ql3R3zX5KFFvqXQxP9akY62iayCl2/a0XPOVY01w"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm"
+                },
+                "uid": "34bdde2e-c3a1-4a1e-abc2-96e637eebd29"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bookworm/20250210-2019/debian-12-genericcloud-amd64-20250210-2019.tar.xz"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:vjkZd5EcOW2XvwbonfpMLzbrX6jWzRvm7EqPQq2VaXTFP+lnD2/JzQKjSFjIxr9Rw2DLpgoBTALr1yViky30ww"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm",
+                    "upload.cloud.debian.org/image-format": "internal",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "7928bcc8-6681-4c52-bf2a-537a51a7829a"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bookworm/20250210-2019/debian-12-genericcloud-amd64-20250210-2019.raw"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:pgNffsMq4+b4IO/GnwCfutJhlhTXIQQovqtuK8DyFfZr+iAiPmz7R46ndoJW3OmPchYdVjj6Edu7CRHyoRtzkQ"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm",
+                    "upload.cloud.debian.org/image-format": "raw",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "195a56a4-1294-41f9-8683-f3833c080ed8"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bookworm/20250210-2019/debian-12-genericcloud-amd64-20250210-2019.qcow2"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:pY2GUl11/Y4TmiMCUxzl0qt17wJzz+ePnVOq2ksj79RfhDO0gG+kVwz+mByPrib15ehVy9ZrohmIYvKBJf0tRQ"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "amd64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm",
+                    "upload.cloud.debian.org/image-format": "qcow2",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "c51759e1-4475-4589-877d-9b315be669ed"
+            }
+        }
+    ],
+    "kind": "List"
+}

--- a/artifacts/debian/testdata/debian-12-genericcloud-arm64.json
+++ b/artifacts/debian/testdata/debian-12-genericcloud-arm64.json
@@ -1,0 +1,1401 @@
+{
+    "apiVersion": "v1",
+    "items": [
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "info": {
+                    "arch": "arm64",
+                    "build_id": "cloud-admin-team-master",
+                    "release": "bookworm",
+                    "release_baseid": "12",
+                    "release_id": "12",
+                    "type": "official",
+                    "vendor": "genericcloud",
+                    "version": "20250210-2019"
+                },
+                "packages": [
+                    {
+                        "name": "adduser",
+                        "version": "3.134"
+                    },
+                    {
+                        "name": "apparmor",
+                        "version": "3.0.8-3"
+                    },
+                    {
+                        "name": "apt",
+                        "version": "2.6.1"
+                    },
+                    {
+                        "name": "apt-listchanges",
+                        "version": "3.24"
+                    },
+                    {
+                        "name": "apt-utils",
+                        "version": "2.6.1"
+                    },
+                    {
+                        "name": "base-files",
+                        "version": "12.4+deb12u9"
+                    },
+                    {
+                        "name": "base-passwd",
+                        "version": "3.6.1"
+                    },
+                    {
+                        "name": "bash",
+                        "version": "5.2.15-2+b7"
+                    },
+                    {
+                        "name": "bash-completion",
+                        "version": "1:2.11-6"
+                    },
+                    {
+                        "name": "bind9-host",
+                        "version": "1:9.18.33-1~deb12u2"
+                    },
+                    {
+                        "name": "bind9-libs:arm64",
+                        "version": "1:9.18.33-1~deb12u2"
+                    },
+                    {
+                        "name": "bsdextrautils",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "bsdutils",
+                        "version": "1:2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "ca-certificates",
+                        "version": "20230311"
+                    },
+                    {
+                        "name": "cloud-guest-utils",
+                        "version": "0.33-1"
+                    },
+                    {
+                        "name": "cloud-image-utils",
+                        "version": "0.33-1"
+                    },
+                    {
+                        "name": "cloud-init",
+                        "version": "22.4.2-1+deb12u2"
+                    },
+                    {
+                        "name": "cloud-initramfs-growroot",
+                        "version": "0.18.debian13+deb12u1"
+                    },
+                    {
+                        "name": "cloud-utils",
+                        "version": "0.33-1"
+                    },
+                    {
+                        "name": "coreutils",
+                        "version": "9.1-1"
+                    },
+                    {
+                        "name": "cpio",
+                        "version": "2.13+dfsg-7.1"
+                    },
+                    {
+                        "name": "curl",
+                        "version": "7.88.1-10+deb12u8"
+                    },
+                    {
+                        "name": "dash",
+                        "version": "0.5.12-2"
+                    },
+                    {
+                        "name": "dbus",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-bin",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-daemon",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-session-bus-common",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "dbus-system-bus-common",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "debconf",
+                        "version": "1.5.82"
+                    },
+                    {
+                        "name": "debian-archive-keyring",
+                        "version": "2023.3+deb12u1"
+                    },
+                    {
+                        "name": "debianutils",
+                        "version": "5.7-0.5~deb12u1"
+                    },
+                    {
+                        "name": "diffutils",
+                        "version": "1:3.8-4"
+                    },
+                    {
+                        "name": "distro-info-data",
+                        "version": "0.58+deb12u3"
+                    },
+                    {
+                        "name": "dmsetup",
+                        "version": "2:1.02.185-2"
+                    },
+                    {
+                        "name": "dpkg",
+                        "version": "1.21.22"
+                    },
+                    {
+                        "name": "e2fsprogs",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "eject",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "ethtool",
+                        "version": "1:6.1-1"
+                    },
+                    {
+                        "name": "fdisk",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "file",
+                        "version": "1:5.44-3"
+                    },
+                    {
+                        "name": "findutils",
+                        "version": "4.9.0-4"
+                    },
+                    {
+                        "name": "gcc-12-base:arm64",
+                        "version": "12.2.0-14"
+                    },
+                    {
+                        "name": "gdisk",
+                        "version": "1.0.9-2.1"
+                    },
+                    {
+                        "name": "genisoimage",
+                        "version": "9:1.1.11-3.4"
+                    },
+                    {
+                        "name": "gettext-base",
+                        "version": "0.21-12"
+                    },
+                    {
+                        "name": "gpgv",
+                        "version": "2.2.40-1.1"
+                    },
+                    {
+                        "name": "grep",
+                        "version": "3.8-5"
+                    },
+                    {
+                        "name": "groff-base",
+                        "version": "1.22.4-10"
+                    },
+                    {
+                        "name": "grub-common",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "grub-efi-arm64",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "grub-efi-arm64-bin",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "grub-efi-arm64-signed",
+                        "version": "1+2.06+13+deb12u1"
+                    },
+                    {
+                        "name": "grub2-common",
+                        "version": "2.06-13+deb12u1"
+                    },
+                    {
+                        "name": "gzip",
+                        "version": "1.12-1"
+                    },
+                    {
+                        "name": "hostname",
+                        "version": "3.23+nmu1"
+                    },
+                    {
+                        "name": "init",
+                        "version": "1.65.2"
+                    },
+                    {
+                        "name": "init-system-helpers",
+                        "version": "1.65.2"
+                    },
+                    {
+                        "name": "initramfs-tools",
+                        "version": "0.142+deb12u1"
+                    },
+                    {
+                        "name": "initramfs-tools-core",
+                        "version": "0.142+deb12u1"
+                    },
+                    {
+                        "name": "iproute2",
+                        "version": "6.1.0-3"
+                    },
+                    {
+                        "name": "iptables",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "iputils-ping",
+                        "version": "3:20221126-1+deb12u1"
+                    },
+                    {
+                        "name": "isc-dhcp-client",
+                        "version": "4.4.3-P1-2"
+                    },
+                    {
+                        "name": "klibc-utils",
+                        "version": "2.0.12-1"
+                    },
+                    {
+                        "name": "kmod",
+                        "version": "30+20221128-1"
+                    },
+                    {
+                        "name": "less",
+                        "version": "590-2.1~deb12u2"
+                    },
+                    {
+                        "name": "libacl1:arm64",
+                        "version": "2.3.1-3"
+                    },
+                    {
+                        "name": "libaio1:arm64",
+                        "version": "0.3.113-4"
+                    },
+                    {
+                        "name": "libapparmor1:arm64",
+                        "version": "3.0.8-3"
+                    },
+                    {
+                        "name": "libapt-pkg6.0:arm64",
+                        "version": "2.6.1"
+                    },
+                    {
+                        "name": "libargon2-1:arm64",
+                        "version": "0~20171227-0.3+deb12u1"
+                    },
+                    {
+                        "name": "libattr1:arm64",
+                        "version": "1:2.5.1-4"
+                    },
+                    {
+                        "name": "libaudit-common",
+                        "version": "1:3.0.9-1"
+                    },
+                    {
+                        "name": "libaudit1:arm64",
+                        "version": "1:3.0.9-1"
+                    },
+                    {
+                        "name": "libblkid1:arm64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libbpf1:arm64",
+                        "version": "1:1.1.0-1"
+                    },
+                    {
+                        "name": "libbrotli1:arm64",
+                        "version": "1.0.9-2+b6"
+                    },
+                    {
+                        "name": "libbsd0:arm64",
+                        "version": "0.11.7-2"
+                    },
+                    {
+                        "name": "libbz2-1.0:arm64",
+                        "version": "1.0.8-5+b1"
+                    },
+                    {
+                        "name": "libc-bin",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "libc-l10n",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "libc6:arm64",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "libcap-ng0:arm64",
+                        "version": "0.8.3-1+b3"
+                    },
+                    {
+                        "name": "libcap2:arm64",
+                        "version": "1:2.66-4"
+                    },
+                    {
+                        "name": "libcap2-bin",
+                        "version": "1:2.66-4"
+                    },
+                    {
+                        "name": "libcbor0.8:arm64",
+                        "version": "0.8.0-2+b1"
+                    },
+                    {
+                        "name": "libcom-err2:arm64",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "libcrypt1:arm64",
+                        "version": "1:4.4.33-2"
+                    },
+                    {
+                        "name": "libcryptsetup12:arm64",
+                        "version": "2:2.6.1-4~deb12u2"
+                    },
+                    {
+                        "name": "libcurl3-gnutls:arm64",
+                        "version": "7.88.1-10+deb12u8"
+                    },
+                    {
+                        "name": "libcurl4:arm64",
+                        "version": "7.88.1-10+deb12u8"
+                    },
+                    {
+                        "name": "libdb5.3:arm64",
+                        "version": "5.3.28+dfsg2-1"
+                    },
+                    {
+                        "name": "libdbus-1-3:arm64",
+                        "version": "1.14.10-1~deb12u1"
+                    },
+                    {
+                        "name": "libdebconfclient0:arm64",
+                        "version": "0.270"
+                    },
+                    {
+                        "name": "libdevmapper1.02.1:arm64",
+                        "version": "2:1.02.185-2"
+                    },
+                    {
+                        "name": "libduktape207:arm64",
+                        "version": "2.7.0-2"
+                    },
+                    {
+                        "name": "libedit2:arm64",
+                        "version": "3.1-20221030-2"
+                    },
+                    {
+                        "name": "libefiboot1:arm64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libefivar1:arm64",
+                        "version": "37-6"
+                    },
+                    {
+                        "name": "libelf1:arm64",
+                        "version": "0.188-2.1"
+                    },
+                    {
+                        "name": "libexpat1:arm64",
+                        "version": "2.5.0-1+deb12u1"
+                    },
+                    {
+                        "name": "libext2fs2:arm64",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "libfdisk1:arm64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libffi8:arm64",
+                        "version": "3.4.4-1"
+                    },
+                    {
+                        "name": "libfido2-1:arm64",
+                        "version": "1.12.0-2+b1"
+                    },
+                    {
+                        "name": "libfreetype6:arm64",
+                        "version": "2.12.1+dfsg-5+deb12u3"
+                    },
+                    {
+                        "name": "libfstrm0:arm64",
+                        "version": "0.6.1-1"
+                    },
+                    {
+                        "name": "libfuse2:arm64",
+                        "version": "2.9.9-6+b1"
+                    },
+                    {
+                        "name": "libfuse3-3:arm64",
+                        "version": "3.14.0-4"
+                    },
+                    {
+                        "name": "libgcc-s1:arm64",
+                        "version": "12.2.0-14"
+                    },
+                    {
+                        "name": "libgcrypt20:arm64",
+                        "version": "1.10.1-3"
+                    },
+                    {
+                        "name": "libgdbm6:arm64",
+                        "version": "1.23-3"
+                    },
+                    {
+                        "name": "libglib2.0-0:arm64",
+                        "version": "2.74.6-2+deb12u5"
+                    },
+                    {
+                        "name": "libgmp10:arm64",
+                        "version": "2:6.2.1+dfsg1-1.1"
+                    },
+                    {
+                        "name": "libgnutls30:arm64",
+                        "version": "3.7.9-2+deb12u3"
+                    },
+                    {
+                        "name": "libgpg-error0:arm64",
+                        "version": "1.46-1"
+                    },
+                    {
+                        "name": "libgpm2:arm64",
+                        "version": "1.20.7-10+b1"
+                    },
+                    {
+                        "name": "libgssapi-krb5-2:arm64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libhogweed6:arm64",
+                        "version": "3.8.1-2"
+                    },
+                    {
+                        "name": "libicu72:arm64",
+                        "version": "72.1-3"
+                    },
+                    {
+                        "name": "libidn2-0:arm64",
+                        "version": "2.3.3-1+b1"
+                    },
+                    {
+                        "name": "libip4tc2:arm64",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "libip6tc2:arm64",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "libjemalloc2:arm64",
+                        "version": "5.3.0-1"
+                    },
+                    {
+                        "name": "libjson-c5:arm64",
+                        "version": "0.16-2"
+                    },
+                    {
+                        "name": "libk5crypto3:arm64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libkeyutils1:arm64",
+                        "version": "1.6.3-2"
+                    },
+                    {
+                        "name": "libklibc:arm64",
+                        "version": "2.0.12-1"
+                    },
+                    {
+                        "name": "libkmod2:arm64",
+                        "version": "30+20221128-1"
+                    },
+                    {
+                        "name": "libkrb5-3:arm64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libkrb5support0:arm64",
+                        "version": "1.20.1-2+deb12u2"
+                    },
+                    {
+                        "name": "libldap-2.5-0:arm64",
+                        "version": "2.5.13+dfsg-5"
+                    },
+                    {
+                        "name": "liblmdb0:arm64",
+                        "version": "0.9.24-1"
+                    },
+                    {
+                        "name": "liblz4-1:arm64",
+                        "version": "1.9.4-1"
+                    },
+                    {
+                        "name": "liblzma5:arm64",
+                        "version": "5.4.1-0.2"
+                    },
+                    {
+                        "name": "libmagic-mgc",
+                        "version": "1:5.44-3"
+                    },
+                    {
+                        "name": "libmagic1:arm64",
+                        "version": "1:5.44-3"
+                    },
+                    {
+                        "name": "libmaxminddb0:arm64",
+                        "version": "1.7.1-1"
+                    },
+                    {
+                        "name": "libmd0:arm64",
+                        "version": "1.0.4-2"
+                    },
+                    {
+                        "name": "libmnl0:arm64",
+                        "version": "1.0.4-3"
+                    },
+                    {
+                        "name": "libmount1:arm64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libncursesw6:arm64",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "libnetfilter-conntrack3:arm64",
+                        "version": "1.0.9-3"
+                    },
+                    {
+                        "name": "libnetplan0:arm64",
+                        "version": "0.106-2+deb12u1"
+                    },
+                    {
+                        "name": "libnettle8:arm64",
+                        "version": "3.8.1-2"
+                    },
+                    {
+                        "name": "libnewt0.52:arm64",
+                        "version": "0.52.23-1+b1"
+                    },
+                    {
+                        "name": "libnfnetlink0:arm64",
+                        "version": "1.0.2-2"
+                    },
+                    {
+                        "name": "libnftnl11:arm64",
+                        "version": "1.2.4-2"
+                    },
+                    {
+                        "name": "libnghttp2-14:arm64",
+                        "version": "1.52.0-1+deb12u2"
+                    },
+                    {
+                        "name": "libnsl2:arm64",
+                        "version": "1.3.0-2"
+                    },
+                    {
+                        "name": "libnss-myhostname:arm64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libnuma1:arm64",
+                        "version": "2.0.16-1"
+                    },
+                    {
+                        "name": "libp11-kit0:arm64",
+                        "version": "0.24.1-2"
+                    },
+                    {
+                        "name": "libpam-modules:arm64",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpam-modules-bin",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpam-runtime",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpam-systemd:arm64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libpam0g:arm64",
+                        "version": "1.5.2-6+deb12u1"
+                    },
+                    {
+                        "name": "libpcap0.8:arm64",
+                        "version": "1.10.3-1"
+                    },
+                    {
+                        "name": "libpci3:arm64",
+                        "version": "1:3.9.0-4"
+                    },
+                    {
+                        "name": "libpcre2-8-0:arm64",
+                        "version": "10.42-1"
+                    },
+                    {
+                        "name": "libpipeline1:arm64",
+                        "version": "1.5.7-1"
+                    },
+                    {
+                        "name": "libpng16-16:arm64",
+                        "version": "1.6.39-2"
+                    },
+                    {
+                        "name": "libpolkit-agent-1-0:arm64",
+                        "version": "122-3"
+                    },
+                    {
+                        "name": "libpolkit-gobject-1-0:arm64",
+                        "version": "122-3"
+                    },
+                    {
+                        "name": "libpopt0:arm64",
+                        "version": "1.19+dfsg-1"
+                    },
+                    {
+                        "name": "libproc2-0:arm64",
+                        "version": "2:4.0.2-3"
+                    },
+                    {
+                        "name": "libprotobuf-c1:arm64",
+                        "version": "1.4.1-1+b1"
+                    },
+                    {
+                        "name": "libpsl5:arm64",
+                        "version": "0.21.2-1"
+                    },
+                    {
+                        "name": "libpython3-stdlib:arm64",
+                        "version": "3.11.2-1+b1"
+                    },
+                    {
+                        "name": "libpython3.11-minimal:arm64",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "libpython3.11-stdlib:arm64",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "libreadline8:arm64",
+                        "version": "8.2-1.3"
+                    },
+                    {
+                        "name": "librtmp1:arm64",
+                        "version": "2.4+20151223.gitfa8646d.1-2+b2"
+                    },
+                    {
+                        "name": "libsasl2-2:arm64",
+                        "version": "2.1.28+dfsg-10"
+                    },
+                    {
+                        "name": "libsasl2-modules-db:arm64",
+                        "version": "2.1.28+dfsg-10"
+                    },
+                    {
+                        "name": "libseccomp2:arm64",
+                        "version": "2.5.4-1+deb12u1"
+                    },
+                    {
+                        "name": "libselinux1:arm64",
+                        "version": "3.4-1+b6"
+                    },
+                    {
+                        "name": "libsemanage-common",
+                        "version": "3.4-1"
+                    },
+                    {
+                        "name": "libsemanage2:arm64",
+                        "version": "3.4-1+b5"
+                    },
+                    {
+                        "name": "libsepol2:arm64",
+                        "version": "3.4-2.1"
+                    },
+                    {
+                        "name": "libslang2:arm64",
+                        "version": "2.3.3-3"
+                    },
+                    {
+                        "name": "libsmartcols1:arm64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libsodium23:arm64",
+                        "version": "1.0.18-1"
+                    },
+                    {
+                        "name": "libsqlite3-0:arm64",
+                        "version": "3.40.1-2+deb12u1"
+                    },
+                    {
+                        "name": "libss2:arm64",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "libssh2-1:arm64",
+                        "version": "1.10.0-3+b1"
+                    },
+                    {
+                        "name": "libssl3:arm64",
+                        "version": "3.0.15-1~deb12u1"
+                    },
+                    {
+                        "name": "libstdc++6:arm64",
+                        "version": "12.2.0-14"
+                    },
+                    {
+                        "name": "libsystemd-shared:arm64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libsystemd0:arm64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libtasn1-6:arm64",
+                        "version": "4.19.0-2"
+                    },
+                    {
+                        "name": "libtinfo6:arm64",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "libtirpc-common",
+                        "version": "1.3.3+ds-1"
+                    },
+                    {
+                        "name": "libtirpc3:arm64",
+                        "version": "1.3.3+ds-1"
+                    },
+                    {
+                        "name": "libuchardet0:arm64",
+                        "version": "0.0.7-1"
+                    },
+                    {
+                        "name": "libudev1:arm64",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "libunistring2:arm64",
+                        "version": "1.0-2"
+                    },
+                    {
+                        "name": "liburing2:arm64",
+                        "version": "2.3-3"
+                    },
+                    {
+                        "name": "libutempter0:arm64",
+                        "version": "1.2.1-3"
+                    },
+                    {
+                        "name": "libuuid1:arm64",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "libuv1:arm64",
+                        "version": "1.44.2-1+deb12u1"
+                    },
+                    {
+                        "name": "libwrap0:arm64",
+                        "version": "7.6.q-32"
+                    },
+                    {
+                        "name": "libxml2:arm64",
+                        "version": "2.9.14+dfsg-1.3~deb12u1"
+                    },
+                    {
+                        "name": "libxtables12:arm64",
+                        "version": "1.8.9-2"
+                    },
+                    {
+                        "name": "libxxhash0:arm64",
+                        "version": "0.8.1-1"
+                    },
+                    {
+                        "name": "libyaml-0-2:arm64",
+                        "version": "0.2.5-1"
+                    },
+                    {
+                        "name": "libzstd1:arm64",
+                        "version": "1.5.4+dfsg2-5"
+                    },
+                    {
+                        "name": "linux-base",
+                        "version": "4.9"
+                    },
+                    {
+                        "name": "linux-image-6.1.0-31-cloud-arm64",
+                        "version": "6.1.128-1"
+                    },
+                    {
+                        "name": "linux-image-cloud-arm64",
+                        "version": "6.1.128-1"
+                    },
+                    {
+                        "name": "locales",
+                        "version": "2.36-9+deb12u9"
+                    },
+                    {
+                        "name": "login",
+                        "version": "1:4.13+dfsg1-1+b1"
+                    },
+                    {
+                        "name": "logsave",
+                        "version": "1.47.0-2"
+                    },
+                    {
+                        "name": "lsb-release",
+                        "version": "12.0-1"
+                    },
+                    {
+                        "name": "man-db",
+                        "version": "2.11.2-2"
+                    },
+                    {
+                        "name": "manpages",
+                        "version": "6.03-2"
+                    },
+                    {
+                        "name": "mawk",
+                        "version": "1.3.4.20200120-3.1"
+                    },
+                    {
+                        "name": "media-types",
+                        "version": "10.0.0"
+                    },
+                    {
+                        "name": "mokutil",
+                        "version": "0.6.0-2"
+                    },
+                    {
+                        "name": "mount",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "nano",
+                        "version": "7.2-1+deb12u1"
+                    },
+                    {
+                        "name": "ncurses-base",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "ncurses-bin",
+                        "version": "6.4-4"
+                    },
+                    {
+                        "name": "netbase",
+                        "version": "6.4"
+                    },
+                    {
+                        "name": "netplan.io",
+                        "version": "0.106-2+deb12u1"
+                    },
+                    {
+                        "name": "openssh-client",
+                        "version": "1:9.2p1-2+deb12u4"
+                    },
+                    {
+                        "name": "openssh-server",
+                        "version": "1:9.2p1-2+deb12u4"
+                    },
+                    {
+                        "name": "openssh-sftp-server",
+                        "version": "1:9.2p1-2+deb12u4"
+                    },
+                    {
+                        "name": "openssl",
+                        "version": "3.0.15-1~deb12u1"
+                    },
+                    {
+                        "name": "passwd",
+                        "version": "1:4.13+dfsg1-1+b1"
+                    },
+                    {
+                        "name": "pci.ids",
+                        "version": "0.0~2023.04.11-1"
+                    },
+                    {
+                        "name": "pciutils",
+                        "version": "1:3.9.0-4"
+                    },
+                    {
+                        "name": "perl-base",
+                        "version": "5.36.0-7+deb12u1"
+                    },
+                    {
+                        "name": "polkitd",
+                        "version": "122-3"
+                    },
+                    {
+                        "name": "procps",
+                        "version": "2:4.0.2-3"
+                    },
+                    {
+                        "name": "psmisc",
+                        "version": "23.6-1"
+                    },
+                    {
+                        "name": "python-apt-common",
+                        "version": "2.6.0"
+                    },
+                    {
+                        "name": "python3",
+                        "version": "3.11.2-1+b1"
+                    },
+                    {
+                        "name": "python3-apt",
+                        "version": "2.6.0"
+                    },
+                    {
+                        "name": "python3-attr",
+                        "version": "22.2.0-1"
+                    },
+                    {
+                        "name": "python3-blinker",
+                        "version": "1.5-1"
+                    },
+                    {
+                        "name": "python3-certifi",
+                        "version": "2022.9.24-1"
+                    },
+                    {
+                        "name": "python3-cffi-backend:arm64",
+                        "version": "1.15.1-5+b1"
+                    },
+                    {
+                        "name": "python3-chardet",
+                        "version": "5.1.0+dfsg-2"
+                    },
+                    {
+                        "name": "python3-charset-normalizer",
+                        "version": "3.0.1-2"
+                    },
+                    {
+                        "name": "python3-configobj",
+                        "version": "5.0.8-1"
+                    },
+                    {
+                        "name": "python3-cryptography",
+                        "version": "38.0.4-3+deb12u1"
+                    },
+                    {
+                        "name": "python3-dbus",
+                        "version": "1.3.2-4+b1"
+                    },
+                    {
+                        "name": "python3-debconf",
+                        "version": "1.5.82"
+                    },
+                    {
+                        "name": "python3-debian",
+                        "version": "0.1.49"
+                    },
+                    {
+                        "name": "python3-debianbts",
+                        "version": "4.0.1"
+                    },
+                    {
+                        "name": "python3-distro",
+                        "version": "1.8.0-1"
+                    },
+                    {
+                        "name": "python3-distro-info",
+                        "version": "1.5+deb12u1"
+                    },
+                    {
+                        "name": "python3-httplib2",
+                        "version": "0.20.4-3"
+                    },
+                    {
+                        "name": "python3-idna",
+                        "version": "3.3-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-jinja2",
+                        "version": "3.1.2-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-json-pointer",
+                        "version": "2.3-2"
+                    },
+                    {
+                        "name": "python3-jsonpatch",
+                        "version": "1.32-2"
+                    },
+                    {
+                        "name": "python3-jsonschema",
+                        "version": "4.10.3-1"
+                    },
+                    {
+                        "name": "python3-jwt",
+                        "version": "2.6.0-1"
+                    },
+                    {
+                        "name": "python3-markdown-it",
+                        "version": "2.1.0-5"
+                    },
+                    {
+                        "name": "python3-markupsafe",
+                        "version": "2.1.2-1+b1"
+                    },
+                    {
+                        "name": "python3-mdurl",
+                        "version": "0.1.2-1"
+                    },
+                    {
+                        "name": "python3-minimal",
+                        "version": "3.11.2-1+b1"
+                    },
+                    {
+                        "name": "python3-netifaces:arm64",
+                        "version": "0.11.0-2+b1"
+                    },
+                    {
+                        "name": "python3-oauthlib",
+                        "version": "3.2.2-1"
+                    },
+                    {
+                        "name": "python3-pkg-resources",
+                        "version": "66.1.1-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-pycurl",
+                        "version": "7.45.2-3"
+                    },
+                    {
+                        "name": "python3-pygments",
+                        "version": "2.14.0+dfsg-1"
+                    },
+                    {
+                        "name": "python3-pyparsing",
+                        "version": "3.0.9-1"
+                    },
+                    {
+                        "name": "python3-pyrsistent:arm64",
+                        "version": "0.18.1-1+b3"
+                    },
+                    {
+                        "name": "python3-pysimplesoap",
+                        "version": "1.16.2-5"
+                    },
+                    {
+                        "name": "python3-reportbug",
+                        "version": "12.0.0"
+                    },
+                    {
+                        "name": "python3-requests",
+                        "version": "2.28.1+dfsg-1"
+                    },
+                    {
+                        "name": "python3-rich",
+                        "version": "13.3.1-1"
+                    },
+                    {
+                        "name": "python3-serial",
+                        "version": "3.5-1.1"
+                    },
+                    {
+                        "name": "python3-six",
+                        "version": "1.16.0-4"
+                    },
+                    {
+                        "name": "python3-urllib3",
+                        "version": "1.26.12-1+deb12u1"
+                    },
+                    {
+                        "name": "python3-yaml",
+                        "version": "6.0-3+b2"
+                    },
+                    {
+                        "name": "python3.11",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "python3.11-minimal",
+                        "version": "3.11.2-6+deb12u5"
+                    },
+                    {
+                        "name": "qemu-utils",
+                        "version": "1:7.2+dfsg-7+deb12u12"
+                    },
+                    {
+                        "name": "readline-common",
+                        "version": "8.2-1.3"
+                    },
+                    {
+                        "name": "reportbug",
+                        "version": "12.0.0"
+                    },
+                    {
+                        "name": "runit-helper",
+                        "version": "2.15.2"
+                    },
+                    {
+                        "name": "screen",
+                        "version": "4.9.0-4"
+                    },
+                    {
+                        "name": "sed",
+                        "version": "4.9-1"
+                    },
+                    {
+                        "name": "sensible-utils",
+                        "version": "0.0.17+nmu1"
+                    },
+                    {
+                        "name": "sgml-base",
+                        "version": "1.31"
+                    },
+                    {
+                        "name": "shim-helpers-arm64-signed",
+                        "version": "1+15.8+1~deb12u1"
+                    },
+                    {
+                        "name": "shim-signed:arm64",
+                        "version": "1.44~1+deb12u1+15.8-1~deb12u1"
+                    },
+                    {
+                        "name": "shim-signed-common",
+                        "version": "1.44~1+deb12u1+15.8-1~deb12u1"
+                    },
+                    {
+                        "name": "shim-unsigned:arm64",
+                        "version": "15.8-1~deb12u1"
+                    },
+                    {
+                        "name": "socat",
+                        "version": "1.7.4.4-2"
+                    },
+                    {
+                        "name": "ssh-import-id",
+                        "version": "5.10-1"
+                    },
+                    {
+                        "name": "sudo",
+                        "version": "1.9.13p3-1+deb12u1"
+                    },
+                    {
+                        "name": "systemd",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "systemd-resolved",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "systemd-sysv",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "systemd-timesyncd",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "sysvinit-utils",
+                        "version": "3.06-4"
+                    },
+                    {
+                        "name": "tar",
+                        "version": "1.34+dfsg-1.2+deb12u1"
+                    },
+                    {
+                        "name": "tcpdump",
+                        "version": "4.99.3-1"
+                    },
+                    {
+                        "name": "traceroute",
+                        "version": "1:2.1.2-1"
+                    },
+                    {
+                        "name": "tzdata",
+                        "version": "2024b-0+deb12u1"
+                    },
+                    {
+                        "name": "ucf",
+                        "version": "3.0043+nmu1+deb12u1"
+                    },
+                    {
+                        "name": "udev",
+                        "version": "252.33-1~deb12u1"
+                    },
+                    {
+                        "name": "unattended-upgrades",
+                        "version": "2.9.1+nmu3"
+                    },
+                    {
+                        "name": "usr-is-merged",
+                        "version": "37~deb12u1"
+                    },
+                    {
+                        "name": "util-linux",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "util-linux-extra",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "uuid-runtime",
+                        "version": "2.38.1-5+deb12u3"
+                    },
+                    {
+                        "name": "vim",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "vim-common",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "vim-runtime",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "vim-tiny",
+                        "version": "2:9.0.1378-2"
+                    },
+                    {
+                        "name": "wget",
+                        "version": "1.21.3-1+b1"
+                    },
+                    {
+                        "name": "whiptail",
+                        "version": "0.52.23-1+b1"
+                    },
+                    {
+                        "name": "xml-core",
+                        "version": "0.18+nmu1"
+                    },
+                    {
+                        "name": "xz-utils",
+                        "version": "5.4.1-0.2"
+                    },
+                    {
+                        "name": "zlib1g:arm64",
+                        "version": "1:1.2.13.dfsg-1"
+                    },
+                    {
+                        "name": "zstd",
+                        "version": "1.5.4+dfsg2-5"
+                    }
+                ]
+            },
+            "kind": "Build",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:oAIN2C09Hz9jkVo+JYgYWel4tSlR5UjidTbF2raeg39BTbcMmP/mN2W7FkE1UffnHGoUyuSF5huxZtvI9sor0g"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm"
+                },
+                "uid": "99f10919-f74d-41b5-bef1-d9771541ffbe"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bookworm/20250210-2019/debian-12-genericcloud-arm64-20250210-2019.tar.xz"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:lH0YsnSrbMfQkZiRaB8oHl7a2P2+gXUK+ksdZcC+oFBaaF5HNEj62mmv9q7YesMKWsLWm7z6fh9UmHdYuAHbiQ"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm",
+                    "upload.cloud.debian.org/image-format": "internal",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "c8c0ceb1-d9c9-4b2d-8b55-0f3433d6a745"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bookworm/20250210-2019/debian-12-genericcloud-arm64-20250210-2019.raw"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:ECtiBc6JYVw8tlLV46rKmU3c5XMmbyxjSSym2oNat1u/90e1Z0yFzmpox+lBysTzaPrhiPzIsCylzpeQD2HTjw"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm",
+                    "upload.cloud.debian.org/image-format": "raw",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "72987600-b42c-4089-8fd9-1889eb6a390d"
+            }
+        },
+        {
+            "apiVersion": "cloud.debian.org/v1alpha1",
+            "data": {
+                "familyRef": null,
+                "provider": "cloud.debian.org",
+                "ref": "bookworm/20250210-2019/debian-12-genericcloud-arm64-20250210-2019.qcow2"
+            },
+            "kind": "Upload",
+            "metadata": {
+                "annotations": {
+                    "cloud.debian.org/digest": "sha512:oXpGKsvDQS7xlTkPtg3/uiE0/vGidtUAylCgYDbEiANWV0CfzQLy9w0eepF3bKQknPvOq+uQ50yxI7mXE4HHKg"
+                },
+                "labels": {
+                    "cloud.debian.org/vendor": "genericcloud",
+                    "cloud.debian.org/version": "20250210-2019",
+                    "debian.org/arch": "arm64",
+                    "debian.org/dist": "debian",
+                    "debian.org/release": "bookworm",
+                    "upload.cloud.debian.org/image-format": "qcow2",
+                    "upload.cloud.debian.org/type": "release"
+                },
+                "uid": "72648693-f935-4d70-b51c-1d46fe214915"
+            }
+        }
+    ],
+    "kind": "List"
+}

--- a/artifacts/fedora/fedora.go
+++ b/artifacts/fedora/fedora.go
@@ -1,6 +1,7 @@
 package fedora
 
 import (
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -86,7 +87,8 @@ func (f *fedora) Inspect() (*api.ArtifactDetails, error) {
 		}
 
 		details := &api.ArtifactDetails{
-			SHA256Sum:         release.Sha256,
+			Checksum:          release.Sha256,
+			ChecksumHash:      sha256.New,
 			DownloadURL:       release.Link,
 			ImageArchitecture: architecture.GetImageArchitecture(f.Arch),
 		}

--- a/artifacts/fedora/fedora_test.go
+++ b/artifacts/fedora/fedora_test.go
@@ -20,12 +20,17 @@ var _ = Describe("Fedora", func() {
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(got).To(Equal(details))
+			Expect(got.ChecksumHash).ToNot(BeNil())
+			Expect(got.Checksum).To(Equal(details.Checksum))
+			Expect(got.DownloadURL).To(Equal(details.DownloadURL))
+			Expect(got.AdditionalUniqueTags).To(Equal(details.AdditionalUniqueTags))
+			Expect(got.ImageArchitecture).To(Equal(details.ImageArchitecture))
+			Expect(got.Compression).To(Equal(details.Compression))
 			Expect(c.Metadata()).To(Equal(metadata))
 		},
 		Entry("fedora:40 x86_64", "40", "x86_64", "testdata/releases.json",
 			&api.ArtifactDetails{
-				SHA256Sum:            "ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee",
+				Checksum:             "ac58f3c35b73272d5986fa6d3bc44fd246b45df4c334e99a07b3bbd00684adee",
 				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/x86_64/images/Fedora-Cloud-Base-Generic.x86_64-40-1.14.qcow2", //nolint:lll
 				AdditionalUniqueTags: []string{"40-1.14"},
 				ImageArchitecture:    "amd64",
@@ -46,7 +51,7 @@ var _ = Describe("Fedora", func() {
 		),
 		Entry("fedora:40 aarch64", "40", "aarch64", "testdata/releases.json",
 			&api.ArtifactDetails{
-				SHA256Sum:            "ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459",
+				Checksum:             "ebdce26d861a9d15072affe1919ed753ec7015bd97b3a7d0d0df6a10834f7459",
 				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/40/Cloud/aarch64/images/Fedora-Cloud-Base-Generic.aarch64-40-1.14.qcow2", //nolint:lll
 				AdditionalUniqueTags: []string{"40-1.14"},
 				ImageArchitecture:    "arm64",
@@ -67,7 +72,7 @@ var _ = Describe("Fedora", func() {
 		),
 		Entry("fedora:40 s390x", "40", "s390x", "testdata/releases.json",
 			&api.ArtifactDetails{
-				SHA256Sum:            "808226b31c6c61e08cde77fe7ba61d766f7528c857e7ae8553040c177cbda9a7",
+				Checksum:             "808226b31c6c61e08cde77fe7ba61d766f7528c857e7ae8553040c177cbda9a7",
 				DownloadURL:          "https://download.fedoraproject.org/pub/fedora-secondary/releases/40/Cloud/s390x/images/Fedora-Cloud-Base-Generic.s390x-40-1.14.qcow2", //nolint:lll
 				AdditionalUniqueTags: []string{"40-1.14"},
 				ImageArchitecture:    "s390x",
@@ -88,7 +93,7 @@ var _ = Describe("Fedora", func() {
 		),
 		Entry("fedora:39 x86_64", "39", "x86_64", "testdata/releases.json",
 			&api.ArtifactDetails{
-				SHA256Sum:            "ab5be5058c5c839528a7d6373934e0ce5ad6c8f80bd71ed3390032027da52f37",
+				Checksum:             "ab5be5058c5c839528a7d6373934e0ce5ad6c8f80bd71ed3390032027da52f37",
 				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-39-1.5.x86_64.qcow2", //nolint:lll
 				AdditionalUniqueTags: []string{"39-1.5"},
 				ImageArchitecture:    "amd64",
@@ -109,7 +114,7 @@ var _ = Describe("Fedora", func() {
 		),
 		Entry("fedora:39 aarch64", "39", "aarch64", "testdata/releases.json",
 			&api.ArtifactDetails{
-				SHA256Sum:            "765996d5b77481ca02d0ac06405641bf134ac920cfc1e60d981c64d7971162dc",
+				Checksum:             "765996d5b77481ca02d0ac06405641bf134ac920cfc1e60d981c64d7971162dc",
 				DownloadURL:          "https://download.fedoraproject.org/pub/fedora/linux/releases/39/Cloud/aarch64/images/Fedora-Cloud-Base-39-1.5.aarch64.qcow2", //nolint:lll
 				AdditionalUniqueTags: []string{"39-1.5"},
 				ImageArchitecture:    "arm64",
@@ -130,7 +135,7 @@ var _ = Describe("Fedora", func() {
 		),
 		Entry("fedora:39 s390x", "39", "s390x", "testdata/releases.json",
 			&api.ArtifactDetails{
-				SHA256Sum:            "36dec66c791c9d1225d74e8828fdb0976ad89f695e8e6f5c93269cafa8563907",
+				Checksum:             "36dec66c791c9d1225d74e8828fdb0976ad89f695e8e6f5c93269cafa8563907",
 				DownloadURL:          "https://download.fedoraproject.org/pub/fedora-secondary/releases/39/Cloud/s390x/images/Fedora-Cloud-Base-39-1.5.s390x.qcow2", //nolint:lll
 				AdditionalUniqueTags: []string{"39-1.5"},
 				ImageArchitecture:    "s390x",

--- a/artifacts/opensuse/leap/leap.go
+++ b/artifacts/opensuse/leap/leap.go
@@ -1,6 +1,7 @@
 package leap
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"strings"
 
@@ -37,7 +38,8 @@ func (l *leap) Inspect() (*api.ArtifactDetails, error) {
 		return nil, err
 	}
 	return &api.ArtifactDetails{
-		SHA256Sum:         strings.Split(string(checksumBytes), " ")[0],
+		Checksum:          strings.Split(string(checksumBytes), " ")[0],
+		ChecksumHash:      sha256.New,
 		DownloadURL:       baseURL,
 		ImageArchitecture: architecture.GetImageArchitecture(l.Arch),
 	}, nil

--- a/artifacts/opensuse/leap/leap_test.go
+++ b/artifacts/opensuse/leap/leap_test.go
@@ -19,8 +19,14 @@ var _ = Describe("OpenSUSE Leap", func() {
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(got).To(Equal(details))
+			Expect(got.ChecksumHash).ToNot(BeNil())
+			Expect(got.Checksum).To(Equal(details.Checksum))
+			Expect(got.DownloadURL).To(Equal(details.DownloadURL))
+			Expect(got.AdditionalUniqueTags).To(Equal(details.AdditionalUniqueTags))
+			Expect(got.ImageArchitecture).To(Equal(details.ImageArchitecture))
+			Expect(got.Compression).To(Equal(details.Compression))
 			Expect(c.Metadata()).To(Equal(metadata))
+			Expect(err).NotTo(HaveOccurred())
 		},
 		Entry("leap:15.6 x86_64", "x86_64", "15.6", "testdata/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2.sha256",
 			map[string]string{
@@ -28,7 +34,7 @@ var _ = Describe("OpenSUSE Leap", func() {
 				common.DefaultPreferenceEnv:   "opensuse.leap",
 			},
 			&api.ArtifactDetails{
-				SHA256Sum:         "0f7f09a9a083088b51aa365fe0e4310e6b156c2153d6aa03a77b81eee884e52a",
+				Checksum:          "0f7f09a9a083088b51aa365fe0e4310e6b156c2153d6aa03a77b81eee884e52a",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.x86_64-Cloud.qcow2",
 				ImageArchitecture: "amd64",
 			},
@@ -49,7 +55,7 @@ var _ = Describe("OpenSUSE Leap", func() {
 		Entry("leap:15.6 aarch64", "aarch64", "15.6", "testdata/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2.sha256",
 			nil,
 			&api.ArtifactDetails{
-				SHA256Sum:         "d2ff40176f8823ab869bf4d728f827ffd6c7f180940b9ccca865be6dc20b06dd",
+				Checksum:          "d2ff40176f8823ab869bf4d728f827ffd6c7f180940b9ccca865be6dc20b06dd",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.6/appliances/openSUSE-Leap-15.6-Minimal-VM.aarch64-Cloud.qcow2",
 				ImageArchitecture: "arm64",
 			},
@@ -69,7 +75,7 @@ var _ = Describe("OpenSUSE Leap", func() {
 				common.DefaultPreferenceEnv:   "opensuse.leap",
 			},
 			&api.ArtifactDetails{
-				SHA256Sum:         "46e63b73fadc17c8b38ff83a45ebf3a736b86310e440ac1bfb123a420af1161f",
+				Checksum:          "46e63b73fadc17c8b38ff83a45ebf3a736b86310e440ac1bfb123a420af1161f",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.x86_64-Cloud.qcow2",
 				ImageArchitecture: "amd64",
 			},
@@ -90,7 +96,7 @@ var _ = Describe("OpenSUSE Leap", func() {
 		Entry("leap:15.5 aarch64", "aarch64", "15.5", "testdata/openSUSE-Leap-15.5-Minimal-VM.aarch64-Cloud.qcow2.sha256",
 			nil,
 			&api.ArtifactDetails{
-				SHA256Sum:         "3560ca0845d797880a1a36ca84b52a6ba1d0bb1e153913312c5e9f3c9cfda56a",
+				Checksum:          "3560ca0845d797880a1a36ca84b52a6ba1d0bb1e153913312c5e9f3c9cfda56a",
 				DownloadURL:       "https://download.opensuse.org/distribution/leap/15.5/appliances/openSUSE-Leap-15.5-Minimal-VM.aarch64-Cloud.qcow2",
 				ImageArchitecture: "arm64",
 			},

--- a/artifacts/opensuse/tumbleweed/tumbleweed.go
+++ b/artifacts/opensuse/tumbleweed/tumbleweed.go
@@ -2,6 +2,7 @@ package tumbleweed
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 	"regexp"
 
@@ -46,7 +47,8 @@ func (t *tumbleweed) Inspect() (*api.ArtifactDetails, error) {
 	for file, checksum := range checksums {
 		if r.MatchString(file) {
 			return &api.ArtifactDetails{
-				SHA256Sum:         checksum,
+				Checksum:          checksum,
+				ChecksumHash:      sha256.New,
 				DownloadURL:       baseURL + file,
 				ImageArchitecture: architecture.GetImageArchitecture(t.Arch),
 			}, nil

--- a/artifacts/opensuse/tumbleweed/tumbleweed_test.go
+++ b/artifacts/opensuse/tumbleweed/tumbleweed_test.go
@@ -20,7 +20,12 @@ var _ = Describe("OpenSUSE Tumbleweed", func() {
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(got).To(Equal(details))
+			Expect(got.ChecksumHash).ToNot(BeNil())
+			Expect(got.Checksum).To(Equal(details.Checksum))
+			Expect(got.DownloadURL).To(Equal(details.DownloadURL))
+			Expect(got.AdditionalUniqueTags).To(Equal(details.AdditionalUniqueTags))
+			Expect(got.ImageArchitecture).To(Equal(details.ImageArchitecture))
+			Expect(got.Compression).To(Equal(details.Compression))
 			Expect(c.Metadata()).To(Equal(metadata))
 		},
 		Entry("tumbleweed:1 x86_64", "x86_64", "testdata/tumbleweed.SHA256SUM",
@@ -29,7 +34,7 @@ var _ = Describe("OpenSUSE Tumbleweed", func() {
 				common.DefaultPreferenceEnv:   "opensuse.tumbleweed",
 			},
 			&api.ArtifactDetails{
-				SHA256Sum:         "e8150b4a7ce5c56587492c930af094236c7a095149d714c015e6860ce6c58e66",
+				Checksum:          "e8150b4a7ce5c56587492c930af094236c7a095149d714c015e6860ce6c58e66",
 				DownloadURL:       "https://download.opensuse.org/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.x86_64-1.0.0-Cloud-Snapshot20240629.qcow2",
 				ImageArchitecture: "amd64",
 			},

--- a/artifacts/ubuntu/ubuntu.go
+++ b/artifacts/ubuntu/ubuntu.go
@@ -2,6 +2,7 @@ package ubuntu
 
 import (
 	"bytes"
+	"crypto/sha256"
 	"fmt"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -54,7 +55,8 @@ func (u *ubuntu) Inspect() (*api.ArtifactDetails, error) {
 	}
 	if checksum, exists := checksums[u.Variant]; exists {
 		return &api.ArtifactDetails{
-			SHA256Sum:         checksum,
+			Checksum:          checksum,
+			ChecksumHash:      sha256.New,
 			DownloadURL:       baseURL + u.Variant,
 			Compression:       u.Compression,
 			ImageArchitecture: architecture.GetImageArchitecture(u.Arch),

--- a/artifacts/ubuntu/ubuntu_test.go
+++ b/artifacts/ubuntu/ubuntu_test.go
@@ -19,12 +19,18 @@ var _ = Describe("Ubuntu", func() {
 			c.getter = testutil.NewMockGetter(mockFile)
 			got, err := c.Inspect()
 			Expect(err).NotTo(HaveOccurred())
-			Expect(got).To(Equal(details))
+			Expect(got.ChecksumHash).ToNot(BeNil())
+			Expect(got.Checksum).To(Equal(details.Checksum))
+			Expect(got.DownloadURL).To(Equal(details.DownloadURL))
+			Expect(got.AdditionalUniqueTags).To(Equal(details.AdditionalUniqueTags))
+			Expect(got.ImageArchitecture).To(Equal(details.ImageArchitecture))
+			Expect(got.Compression).To(Equal(details.Compression))
 			Expect(c.Metadata()).To(Equal(metadata))
+			Expect(err).NotTo(HaveOccurred())
 		},
 		Entry("ubuntu:22.04 x86_64", "22.04", "x86_64", "testdata/SHA256SUM",
 			&api.ArtifactDetails{
-				SHA256Sum:         "de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd",
+				Checksum:          "de5e632e17b8965f2baf4ea6d2b824788e154d9a65df4fd419ec4019898e15cd",
 				DownloadURL:       "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-amd64.img",
 				ImageArchitecture: "amd64",
 			},
@@ -48,7 +54,7 @@ var _ = Describe("Ubuntu", func() {
 		),
 		Entry("ubuntu:22.04 aarch64", "22.04", "aarch64", "testdata/SHA256SUM",
 			&api.ArtifactDetails{
-				SHA256Sum:         "66224c7fed99ff5a5539eda406c87bbfefe8af6ff6b47d92df3187832b5b5d4f",
+				Checksum:          "66224c7fed99ff5a5539eda406c87bbfefe8af6ff6b47d92df3187832b5b5d4f",
 				DownloadURL:       "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-arm64.img",
 				ImageArchitecture: "arm64",
 			},
@@ -72,7 +78,7 @@ var _ = Describe("Ubuntu", func() {
 		),
 		Entry("ubuntu:22.04 s390x", "22.04", "s390x", "testdata/SHA256SUM",
 			&api.ArtifactDetails{
-				SHA256Sum:         "192c18a58917622e12a3bb6aaf246fcc6a76d9562eb9f49d34df81fbc59610af",
+				Checksum:          "192c18a58917622e12a3bb6aaf246fcc6a76d9562eb9f49d34df81fbc59610af",
 				DownloadURL:       "https://cloud-images.ubuntu.com/releases/22.04/release/ubuntu-22.04-server-cloudimg-s390x.img",
 				ImageArchitecture: "s390x",
 			},

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"kubevirt.io/containerdisks/artifacts/centosstream"
+	"kubevirt.io/containerdisks/artifacts/debian"
 	"kubevirt.io/containerdisks/artifacts/fedora"
 	"kubevirt.io/containerdisks/artifacts/generic"
 	"kubevirt.io/containerdisks/artifacts/opensuse/leap"
@@ -83,6 +84,19 @@ var staticRegistry = []Entry{
 			leap.New("x86_64", "15.5", defaultEnvVariables("u1.medium", "opensuse.leap")),
 			leap.New("aarch64", "15.5", defaultEnvVariables("u1.medium", "opensuse.leap")),
 		},
+	},
+	{
+		Artifacts: []api.Artifact{
+			debian.New("11", "bullseye", "x86_64", &docs.UserData{Username: "debian"}, nil),
+			debian.New("11", "bullseye", "aarch64", &docs.UserData{Username: "debian"}, nil),
+		},
+	},
+	{
+		Artifacts: []api.Artifact{
+			debian.New("12", "bookworm", "x86_64", &docs.UserData{Username: "debian"}, nil),
+			debian.New("12", "bookworm", "aarch64", &docs.UserData{Username: "debian"}, nil),
+		},
+		UseForDocs: true,
 	},
 	// for testing only
 	{

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -1,6 +1,7 @@
 package common
 
 import (
+	"crypto/sha256"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -88,7 +89,8 @@ var staticRegistry = []Entry{
 		Artifacts: []api.Artifact{
 			generic.New(
 				&api.ArtifactDetails{
-					SHA256Sum:         "cc704ab14342c1c8a8d91b66a7fc611d921c8b8f1aaf4695f9d6463d913fa8d1",
+					Checksum:          "cc704ab14342c1c8a8d91b66a7fc611d921c8b8f1aaf4695f9d6463d913fa8d1",
+					ChecksumHash:      sha256.New,
 					DownloadURL:       "https://download.cirros-cloud.net/0.6.1/cirros-0.6.1-x86_64-disk.img",
 					ImageArchitecture: "amd64",
 				},
@@ -99,7 +101,8 @@ var staticRegistry = []Entry{
 			),
 			generic.New(
 				&api.ArtifactDetails{
-					SHA256Sum:         "db9420c481c11dee17860aa46fb1a3efa05fa4fb152726d6344e24da03cb0ccf",
+					Checksum:          "db9420c481c11dee17860aa46fb1a3efa05fa4fb152726d6344e24da03cb0ccf",
+					ChecksumHash:      sha256.New,
 					DownloadURL:       "https://download.cirros-cloud.net/0.6.1/cirros-0.6.1-aarch64-disk.img",
 					ImageArchitecture: "arm64",
 				},

--- a/pkg/api/artifact.go
+++ b/pkg/api/artifact.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"hash"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -28,8 +29,10 @@ type ArtifactResult struct {
 }
 
 type ArtifactDetails struct {
-	// SHA256Sum is the checksum of the image to download.
-	SHA256Sum string
+	// Checksum is the checksum of the image to download.
+	Checksum string
+	// ChecksumHash is the digest function used to compute the checksum
+	ChecksumHash func() hash.Hash
 	// DownloadURL points to the target image.
 	DownloadURL string
 	// ImageArchitecture is the target architecture of the image.

--- a/testutil/mockgetter.go
+++ b/testutil/mockgetter.go
@@ -2,6 +2,7 @@ package testutil
 
 import (
 	"context"
+	"hash"
 	"os"
 
 	"kubevirt.io/containerdisks/pkg/http"
@@ -19,11 +20,11 @@ func (m *mockGetter) GetAllWithContext(_ context.Context, _ string) ([]byte, err
 	return os.ReadFile(m.mockFile)
 }
 
-func (m *mockGetter) GetWithChecksum(_ string) (http.ReadCloserWithChecksum, error) {
+func (m *mockGetter) GetWithChecksum(_ string, _ func() hash.Hash) (http.ReadCloserWithChecksum, error) {
 	panic("implement me")
 }
 
-func (m *mockGetter) GetWithChecksumAndContext(_ context.Context, _ string) (http.ReadCloserWithChecksum, error) {
+func (m *mockGetter) GetWithChecksumAndContext(_ context.Context, _ string, _ func() hash.Hash) (http.ReadCloserWithChecksum, error) {
 	panic("implement me")
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:

It adds support for sha512 checksums, which are required by Debian. Debian image repository only provides sha512 checksums. Moreover, it adds support for Debian 11 and 12 containerdisk on x86_64 and aarm64.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes # [CNV-51712](https://issues.redhat.com/browse/CNV-51712)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added support for Debian 11 and 12 containerdisks.
```
