### PR TITLE
Bump golang to 1.24.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ medius:
 	CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH) go build -o bin/medius kubevirt.io/containerdisks/cmd/medius
 
 fmt: gofumpt
-	go mod tidy -compat=1.23
+	go mod tidy -compat=1.24
 	$(GOFUMPT) -w -extra .
 
 .PHONY: vendor

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module kubevirt.io/containerdisks
 
-go 1.23.6
+go 1.24.1
 
 replace (
 	// Fixed versions for kubevirt.io/client-go v1.4.x


### PR DESCRIPTION
Bump golang to 1.24.1

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Bump golang to 1.24.1

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
