### PR TITLE
chore(debian): Apply `latest` tag to Debian 12

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -96,7 +96,8 @@ var staticRegistry = []Entry{
 			debian.New("12", "bookworm", "x86_64", &docs.UserData{Username: "debian"}, nil),
 			debian.New("12", "bookworm", "aarch64", &docs.UserData{Username: "debian"}, nil),
 		},
-		UseForDocs: true,
+		UseForDocs:   true,
+		UseForLatest: true,
 	},
 	// for testing only
 	{


### PR DESCRIPTION
**What this PR does / why we need it**:

It will it make more convenient for users just to look for `debian:latest` containerdisk if they just want the most recent version of Debian available.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
