### PR TITLE
chore(debian): Add `debian` preference and instancetype to Debian containerdisks

### DIFF
--- a/artifacts/debian/debian_test.go
+++ b/artifacts/debian/debian_test.go
@@ -7,6 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"kubevirt.io/containerdisks/pkg/api"
+	"kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/testutil"
 )
@@ -40,7 +41,10 @@ var _ = Describe("Debian", func() {
 			&docs.UserData{
 				Username: "debian",
 			},
-			nil,
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "debian",
+			},
 			&api.Metadata{
 				Name:        "debian",
 				Version:     "11",
@@ -49,7 +53,10 @@ var _ = Describe("Debian", func() {
 				ExampleUserData: docs.UserData{
 					Username: "debian",
 				},
-				EnvVariables: nil,
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "debian",
+				},
 			},
 		),
 		Entry("debian:11 aarch64", "11", "bullseye", "aarch64", "testdata/debian-11-genericcloud-arm64.json",
@@ -63,7 +70,10 @@ var _ = Describe("Debian", func() {
 			&docs.UserData{
 				Username: "debian",
 			},
-			nil,
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "debian",
+			},
 			&api.Metadata{
 				Name:        "debian",
 				Version:     "11",
@@ -72,7 +82,10 @@ var _ = Describe("Debian", func() {
 				ExampleUserData: docs.UserData{
 					Username: "debian",
 				},
-				EnvVariables: nil,
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "debian",
+				},
 			},
 		),
 		Entry("debian:12 x86_64", "12", "bookworm", "x86_64", "testdata/debian-12-genericcloud-amd64.json",
@@ -86,7 +99,10 @@ var _ = Describe("Debian", func() {
 			&docs.UserData{
 				Username: "debian",
 			},
-			nil,
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "debian",
+			},
 			&api.Metadata{
 				Name:        "debian",
 				Version:     "12",
@@ -95,7 +111,10 @@ var _ = Describe("Debian", func() {
 				ExampleUserData: docs.UserData{
 					Username: "debian",
 				},
-				EnvVariables: nil,
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "debian",
+				},
 			},
 		),
 		Entry("debian:12 aarch64", "12", "bookworm", "aarch64", "testdata/debian-12-genericcloud-arm64.json",
@@ -109,7 +128,10 @@ var _ = Describe("Debian", func() {
 			&docs.UserData{
 				Username: "debian",
 			},
-			nil,
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "debian",
+			},
 			&api.Metadata{
 				Name:        "debian",
 				Version:     "12",
@@ -118,7 +140,10 @@ var _ = Describe("Debian", func() {
 				ExampleUserData: docs.UserData{
 					Username: "debian",
 				},
-				EnvVariables: nil,
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "debian",
+				},
 			},
 		),
 	)

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -87,14 +87,14 @@ var staticRegistry = []Entry{
 	},
 	{
 		Artifacts: []api.Artifact{
-			debian.New("11", "bullseye", "x86_64", &docs.UserData{Username: "debian"}, nil),
-			debian.New("11", "bullseye", "aarch64", &docs.UserData{Username: "debian"}, nil),
+			debian.New("11", "bullseye", "x86_64", &docs.UserData{Username: "debian"}, defaultEnvVariables("u1.medium", "debian")),
+			debian.New("11", "bullseye", "aarch64", &docs.UserData{Username: "debian"}, defaultEnvVariables("u1.medium", "debian")),
 		},
 	},
 	{
 		Artifacts: []api.Artifact{
-			debian.New("12", "bookworm", "x86_64", &docs.UserData{Username: "debian"}, nil),
-			debian.New("12", "bookworm", "aarch64", &docs.UserData{Username: "debian"}, nil),
+			debian.New("12", "bookworm", "x86_64", &docs.UserData{Username: "debian"}, defaultEnvVariables("u1.medium", "debian")),
+			debian.New("12", "bookworm", "aarch64", &docs.UserData{Username: "debian"}, defaultEnvVariables("u1.medium", "debian")),
 		},
 		UseForDocs:   true,
 		UseForLatest: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

It provides a default preference and instance type for Debian containerdisks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #  [CNV-58379](https://issues.redhat.com/browse/CNV-58379)

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None.
```
