### PR TITLE
feat(ubuntu): Add Ubuntu 25.04

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -44,6 +44,14 @@ var staticRegistry = []Entry{
 	},
 	{
 		Artifacts: []api.Artifact{
+			ubuntu.New("25.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("25.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("25.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
+		},
+		UseForDocs: false,
+	},
+	{
+		Artifacts: []api.Artifact{
 			ubuntu.New("24.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("24.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("24.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),


### PR DESCRIPTION
**What this PR does / why we need it**:

This adds the latest Ubuntu release `25.04` (Plucky Puffin) which will be supported from April 2025 until January 2026.

Version `25.04` is not a LTS release so it could be debated if it necessary to include it. 
However one of the nice benefits of kubevirt compared to containers in Kubernetes is the possibility to [run newer Linux kernels](https://blog.cloudflare.com/leveraging-kubernetes-virtual-machines-with-kubevirt/#our-need-for-virtualization), thus having access to current releases as a trusted published containerdisk is very useful.

At a current point in the time there would be up to 5 Ubuntu versions in standard support, 3 LTS releases and up to 2 current releases: https://ubuntu.com/about/release-cycle or https://endoflife.date/ubuntu
So the noise of a still very well manageable number of current Ubuntu versions is still acceptable from my perspective.

As another example the Docker official images for Ubuntu also have the non-LTS releases during their standard support window, thus 5 versions there too: https://hub.docker.com/_/ubuntu/

When the support window for this non-LTS version ends, it can just be replaced by the next successor version. As the old tags remain in the quay.io registry there is no risk of breaking configs as the old versions can still be referenced, they just don't receive updates anymore then.

**Release note**:
```release-note
Added support for Ubuntu 25.04 (Plucky Puffin)
```
