### PR TITLE
ci: periodic pipeline can perform a dry run of the promote step

### DIFF
--- a/pipeline-periodic.sh
+++ b/pipeline-periodic.sh
@@ -2,9 +2,10 @@
 
 set -e -o pipefail
 
-make medius
-
 export KUBEVIRT_MEMORY_SIZE=9216M
+PROMOTE_DRY_RUN=${PROMOTE_DRY_RUN:-false}
+
+make medius
 make cluster-up
 trap '{ make cluster-down; }' EXIT SIGINT SIGTERM
 
@@ -18,7 +19,7 @@ fi
 
 ./bin/medius images push --no-fail --dry-run=false --target-registry="${registry}" --insecure-skip-tls --workers 3 "${medius_push_extra_args[@]}"
 ./bin/medius images verify --no-fail --dry-run=false --kubeconfig="${kubeconfig}" --registry="registry:5000" --insecure-skip-tls --workers 3
-./bin/medius images promote --dry-run=false --source-registry="${registry}" --insecure-skip-tls --workers 3
+./bin/medius images promote --dry-run="${PROMOTE_DRY_RUN}" --source-registry="${registry}" --insecure-skip-tls --workers 3
 
 if [ -n "${QUAY_OAUTH_TOKEN}" ]; then
     ./bin/medius docs publish --dry-run=false --quay-token-file="${QUAY_OAUTH_TOKEN}"


### PR DESCRIPTION
This approach allows for code reuse, enabling testing of different architectures without the need to promote changes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
