### PR TITLE
docs: Add virtctl create examples 

### DIFF
--- a/cmd/medius/docs/docs.go
+++ b/cmd/medius/docs/docs.go
@@ -14,6 +14,7 @@ import (
 
 	"kubevirt.io/containerdisks/cmd/medius/common"
 	"kubevirt.io/containerdisks/pkg/api"
+	pkgcommon "kubevirt.io/containerdisks/pkg/common"
 	"kubevirt.io/containerdisks/pkg/docs"
 	"kubevirt.io/containerdisks/pkg/quay"
 )
@@ -131,9 +132,10 @@ func getPreferredArtifact(artifacts []api.Artifact) (api.Artifact, error) {
 
 func createDescription(artifact api.Artifact, registry string) (string, error) {
 	metadata := artifact.Metadata()
+	image := path.Join(registry, metadata.Describe())
 	vm := artifact.VM(
 		metadata.Name,
-		path.Join(registry, metadata.Describe()),
+		image,
 		artifact.UserData(&metadata.ExampleUserData),
 	)
 
@@ -143,9 +145,12 @@ func createDescription(artifact api.Artifact, registry string) (string, error) {
 	}
 
 	data := &docs.TemplateData{
-		Name:        metadata.Name,
-		Description: metadata.Description,
-		Example:     string(example),
+		Name:         metadata.Name,
+		Description:  metadata.Description,
+		Example:      string(example),
+		Image:        image,
+		Instancetype: metadata.EnvVariables[pkgcommon.DefaultInstancetypeEnv],
+		Preference:   metadata.EnvVariables[pkgcommon.DefaultPreferenceEnv],
 	}
 
 	var result bytes.Buffer

--- a/pkg/docs/data/description.tpl
+++ b/pkg/docs/data/description.tpl
@@ -5,13 +5,34 @@
 ## Documentation
 
 This image is maintained by [KubeVirt](https://kubevirt.io/) and automatically created from https://github.com/kubevirt/containerdisks.
-
-For how to get started with `KubeVirt` visit the [UserGuide](https://kubevirt.io/user-guide/)
+<br />
+<br />
+For how to get started with `KubeVirt` visit the [user guide](https://kubevirt.io/user-guide/):
   * [Installation](https://kubevirt.io/user-guide/operations/installation/#installing-kubevirt-on-kubernetes)
-  * [ContainerDisks](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk)
+  * [Containerdisks](https://kubevirt.io/user-guide/virtual_machines/disks_and_volumes/#containerdisk)
+  * [virtctl](https://kubevirt.io/user-guide/user_workloads/virtctl_client_tool)
+  * [Creating VirtualMachines by using virtctl](https://kubevirt.io/user-guide/user_workloads/creating_vms/#creating-virtualmachines-by-using-virtctl)
 
-## Example
+## Examples
+
+### Creating a VirtualMachine and importing this containerdisk with virtctl
+
+You can create a VirtualMachine that will import this containerdisk by running the following command:
+
+```shell
+virtctl create vm {{ if .Instancetype }}--instancetype={{ .Instancetype }} {{ end }}{{ if .Preference }}--preference={{ .Preference }} {{ end }}--volume-import=type:registry,url:docker://{{ .Image }},size:10Gi | kubectl create -f -
+```
+
+### Creating a VirtualMachine without persistence with virtctl
+
+You can create a VirtualMachine that will use this containerdisk as an ephemeral volume by running the following command:
+
+```shell
+virtctl create vm {{ if .Instancetype }}--instancetype={{ .Instancetype }} {{ end }}{{ if .Preference }}--preference={{ .Preference }} {{ end }}--volume-containerdisk=src:{{ .Image }} | kubectl create -f -
+```
+
+### Using this containerdisk in a VirtualMachine definition
 
 ```yaml
-{{ .Example }}
+{{ .Example -}}
 ```

--- a/pkg/docs/docs.go
+++ b/pkg/docs/docs.go
@@ -16,9 +16,12 @@ import (
 )
 
 type TemplateData struct {
-	Name        string
-	Description string
-	Example     string
+	Name         string
+	Description  string
+	Example      string
+	Image        string
+	Instancetype string
+	Preference   string
 }
 
 type UserData struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

This extends description.tpl with examples, that show how to use or
import containerdisks with virtctl create.

It also introduces the getPreferredArtifact helper, which will try to find
the artifact with the amd64 to allow using it for documentation purposes.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
