### PR TITLE
add openSUSE Tumbleweed aarch64

### DIFF
--- a/artifacts/opensuse/tumbleweed/testdata/openSUSE-Tumbleweed-Minimal-VM.aarch64-1.0.0-Cloud-Snapshot20260207.qcow2.sha256
+++ b/artifacts/opensuse/tumbleweed/testdata/openSUSE-Tumbleweed-Minimal-VM.aarch64-1.0.0-Cloud-Snapshot20260207.qcow2.sha256
@@ -1,0 +1,1 @@
+0041ced2a380b10b6227c5504a28c88c40dcd4a7259511f30024aff22270f189  openSUSE-Tumbleweed-Minimal-VM.aarch64-1.0.0-Cloud-Snapshot20260207.qcow2

--- a/artifacts/opensuse/tumbleweed/tumbleweed.go
+++ b/artifacts/opensuse/tumbleweed/tumbleweed.go
@@ -62,6 +62,9 @@ func (t *tumbleweed) retrieveBaseURL() string {
 	if t.Arch == s390xArch {
 		return "https://download.opensuse.org/ports/zsystems/tumbleweed/appliances/"
 	}
+	if t.Arch == "aarch64" {
+		return "https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/"
+	}
 	return "https://download.opensuse.org/tumbleweed/appliances/"
 }
 

--- a/artifacts/opensuse/tumbleweed/tumbleweed_test.go
+++ b/artifacts/opensuse/tumbleweed/tumbleweed_test.go
@@ -76,6 +76,30 @@ var _ = Describe("OpenSUSE Tumbleweed", func() {
 				Arch: "s390x",
 			},
 		),
+		Entry("tumbleweed:1 aarch64", "aarch64", "testdata/openSUSE-Tumbleweed-Minimal-VM.aarch64-1.0.0-Cloud-Snapshot20260207.qcow2.sha256",
+			map[string]string{
+				common.DefaultInstancetypeEnv: "u1.medium",
+				common.DefaultPreferenceEnv:   "opensuse.tumbleweed",
+			},
+			&api.ArtifactDetails{
+				Checksum:          "0041ced2a380b10b6227c5504a28c88c40dcd4a7259511f30024aff22270f189",
+				DownloadURL:       "https://download.opensuse.org/ports/aarch64/tumbleweed/appliances/openSUSE-Tumbleweed-Minimal-VM.aarch64-1.0.0-Cloud-Snapshot20260207.qcow2",
+				ImageArchitecture: "aarch64",
+			},
+			&api.Metadata{
+				Name:        "opensuse-tumbleweed",
+				Version:     "1.0.0",
+				Description: description,
+				ExampleUserData: docs.UserData{
+					Username: "opensuse",
+				},
+				EnvVariables: map[string]string{
+					common.DefaultInstancetypeEnv: "u1.medium",
+					common.DefaultPreferenceEnv:   "opensuse.tumbleweed",
+				},
+				Arch: "aarch64",
+			},
+		),
 	)
 })
 

--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -77,6 +77,7 @@ var staticRegistry = []Entry{
 	{
 		Artifacts: []api.Artifact{
 			tumbleweed.New("x86_64", defaultEnvVariables("u1.medium", "opensuse.tumbleweed")),
+			tumbleweed.New("aarch64", defaultEnvVariables("u1.medium", "opensuse.tumbleweed")),
 			tumbleweed.New("s390x", defaultEnvVariables("u1.medium", "opensuse.tumbleweed")),
 		},
 		UseForDocs: true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Add an image for openSUSE Tumbleweed on aarch64.
