### PR TITLE
artifacts/opensuse/microos: Fix user used by cloud-init

### DIFF
--- a/artifacts/opensuse/microos/microos.go
+++ b/artifacts/opensuse/microos/microos.go
@@ -87,7 +87,7 @@ func (t *microos) Metadata() *api.Metadata {
 		Version:     microOSVersion,
 		Description: description,
 		ExampleUserData: docs.UserData{
-			Username: "opensuse",
+			Username: "root",
 		},
 		EnvVariables: t.envVariables,
 		Arch:         t.Arch,

--- a/artifacts/opensuse/microos/microos_test.go
+++ b/artifacts/opensuse/microos/microos_test.go
@@ -43,7 +43,7 @@ var _ = Describe("openSUSE MicroOS", func() {
 				Version:     "16.0.0",
 				Description: description,
 				ExampleUserData: docs.UserData{
-					Username: "opensuse",
+					Username: "root",
 				},
 				EnvVariables: map[string]string{
 					common.DefaultInstancetypeEnv: "u1.medium",
@@ -67,7 +67,7 @@ var _ = Describe("openSUSE MicroOS", func() {
 				Version:     "16.0.0",
 				Description: description,
 				ExampleUserData: docs.UserData{
-					Username: "opensuse",
+					Username: "root",
 				},
 				EnvVariables: map[string]string{
 					common.DefaultInstancetypeEnv: "u1.medium",


### PR DESCRIPTION
cloud-init-config-MicroOS explicitly uses only the root user. Adapt to it.

**What this PR does / why we need it**:

Fixes a kubevirtci failure for the opensuse-microos:16 image, reported also downstream: https://bugzilla.opensuse.org/show_bug.cgi?id=1262481

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
