### PR TITLE
add Ubuntu 26.04

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -62,6 +62,14 @@ var staticRegistry = []Entry{
 	},
 	{
 		Artifacts: []api.Artifact{
+			ubuntu.New("26.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("26.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("26.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
+		},
+		UseForDocs: false,
+	},
+	{
+		Artifacts: []api.Artifact{
 			ubuntu.New("25.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("25.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("25.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:

Adds the new Ubuntu LTS (26.04) to the containerdisks repo

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add Ubuntu 26.04 LTS
```
