### PR TITLE
feat(ubuntu): Add 26.04 Resolute Raccoon

### DIFF
--- a/cmd/medius/common/registry.go
+++ b/cmd/medius/common/registry.go
@@ -62,6 +62,14 @@ var staticRegistry = []Entry{
 	},
 	{
 		Artifacts: []api.Artifact{
+			ubuntu.New("26.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("26.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
+			ubuntu.New("26.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
+		},
+		UseForDocs: true,
+	},
+	{
+		Artifacts: []api.Artifact{
 			ubuntu.New("25.04", "x86_64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("25.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("25.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
@@ -74,7 +82,7 @@ var staticRegistry = []Entry{
 			ubuntu.New("24.04", "aarch64", defaultEnvVariables("u1.medium", "ubuntu")),
 			ubuntu.New("24.04", "s390x", defaultEnvVariables("u1.medium", "ubuntu")),
 		},
-		UseForDocs: true,
+		UseForDocs: false,
 	},
 	{
 		Artifacts: []api.Artifact{


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the newest LTS version of Ubuntu to the set of containerdisks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Ubuntu 26.04 Resolute Raccoon containerdisks are now provided by the project.
```
