### PR TITLE
fix(kubevirtci): Add curl failure flags and quote variable

### DIFF
--- a/hack/kubevirtci.sh
+++ b/hack/kubevirtci.sh
@@ -21,8 +21,8 @@ set -ex
 
 export KUBEVIRT_MEMORY_SIZE="${KUBEVIRT_MEMORY_SIZE:-16G}"
 export KUBEVIRT_DEPLOY_CDI="true"
-export KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-$(curl -L https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)}
-export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -sfL https://raw.githubusercontent.com/kubevirt/kubevirt/"${KUBEVIRT_VERSION}"/kubevirtci/cluster-up/version.txt)}
+export KUBEVIRT_VERSION=${KUBEVIRT_VERSION:-$(curl -fL https://storage.googleapis.com/kubevirt-prow/devel/release/kubevirt/kubevirt/stable.txt)}
+export KUBEVIRTCI_TAG=${KUBEVIRTCI_TAG:-$(curl -fL https://raw.githubusercontent.com/kubevirt/kubevirt/"${KUBEVIRT_VERSION}"/kubevirtci/cluster-up/version.txt)}
 
 _base_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
 _cluster_up_dir="${_base_dir}/_cluster-up"
@@ -33,7 +33,7 @@ _action=$1
 shift
 
 function kubevirtci::fetch_kubevirtci() {
-	if [[ ! -d ${_cluster_up_dir} ]]; then
+	if [[ ! -d "${_cluster_up_dir}" ]]; then
     git clone --depth 1 --branch "${KUBEVIRTCI_TAG}" https://github.com/kubevirt/kubevirtci.git "${_cluster_up_dir}"
   fi
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Address review feedback from #569:
- Add `-f` flag to curl commands so non-2xx responses cause explicit failures instead of silently proceeding with an empty value
- Drop `-s` (silent) flag so HTTP errors are visible in CI logs
- Quote `${_cluster_up_dir}` in the `-d` test for consistent bash quoting practices

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

Addresses review comments from https://github.com/kubevirt/containerdisks/pull/569#discussion_r3749438093 and https://github.com/kubevirt/containerdisks/pull/569#discussion_r3749512016.

**Release note**:
```release-note
None
```